### PR TITLE
Reformat markdown to fit 80 chars limit

### DIFF
--- a/en/help-uboot.md
+++ b/en/help-uboot.md
@@ -20,3 +20,111 @@ __OpenIPC Linux:__
 root@openipc-hi3518ev100:~# fw_setenv uk 'mw.b 0x82000000 ff 1000000; tftp 0x82000000 uImage.${soc}; sf probe 0; sf erase 0x50000 0x200000; sf write 0x82000000 0x50000 ${filesize}'
 root@openipc-hi3518ev100:~#
 ```
+
+### Saving original firmware without using tftp.
+
+In the terminal program you use connect to UART port with, enable saving a log
+file of the session. I like to use `screen` for that, and my command to connect
+to the UART adapter with logging of the active session into a file would look
+like this:
+```
+$ screen -L -Logfile fulldump.log /dev/ttyUSB0 115200
+```
+
+After connecting to bootloader console, run a command for reading hexadecimal
+dump of data from the very beginning of the flash memery to the very end of it.
+Use hexadecimal notation for addresses, where 0 is 0x0, 8 MB is 8x00000, and
+16 MB is 0x1000000. 
+
+For reading whole 8 MB flash memory run 
+```
+md.b 0x0 0x800000
+```
+and for 16 MB flash memory run
+```
+md.b 0x0 0x1000000
+```
+Since the process of reading is going to take a considerable amount of time
+(literally hours), you might want to disconnect from the terminal session to
+avoid accidental keystrokes contaminating the output. Press `Ctrl-a` followed
+by `d` to detach the session from active terminal. Run `screen -r` when you 
+need to reconnect it later, after the size of the log file will stop growing.
+Reading of an 8 MB flash memory should result in a ~40 MB log file, and for a
+16 MB chip the file should be twice that size.
+
+Convert the hex dump into a binary firmware file using `xxd` and keep it for
+further research or restoring camera to its pristine state.
+
+Using [binwalk](https://github.com/ReFirmLabs/binwalk) to unpack the binary file. 
+
+#### Saving firmware via SD card.
+
+Sometimes your camera only has a wireless connection, which does not work
+directly from the bootloader. Very often such cameras have a microSD card slot.
+In this case you can try to save a copy of the original firmware using an
+SD card as an intermediary medium.
+
+Since you're going to save firmware in its binary form, the amount of data will
+be either 8 MB or 16 MB, depending on the size of camera's flash memory chip.
+So any SD card will do, even the smallest one.
+
+Insert the card into the card slot on the camera, connect the serial adapter to
+the UART port, supply power to the camera and stop the boot process to get into
+the bootloader console.
+
+Initialize access to the card, and clear some space to save firmware on.
+Data is written onto card in blocks of 512 bytes. You need to erase 16384 blocks
+to clear 8 MB, 32768 blocks for 16 MB, which are 0x4000 and 0x8000 hexadecimal,
+respectively.
+
+Note that we are going to write directly to the card registers, bypassing the
+partition table. To avoid conflicts when accessing card data later from your PC,
+offset 8 kilobytes from the beginning of the card (8 * 1024 = 8192 bytes or 16
+blocks of 512 bytes, or 0x10 blocks in hexadecimal representation).
+
+```
+mmc dev 0
+mmc erase 0x10 0x8000
+```
+
+Now you need to copy the contents of the firmware from the flash memory chip to
+the RAM of the camera. To do that, clear a section of RAM (0x800000 bytes for a
+8MB chip or 0x1000000 bytes for a 16MB chip), read the flash memory and copy
+the entire contents to the prepared space in RAM. Then export the copied data
+from RAM to the card.
+
+NB! In the example below we use the starting address 0x2000000, but it varies
+for different cameras. Please consult SoC data sheet, or seek help on
+[our Telegram channel][telegram].
+
+```
+mw.b 0x2000000 ff 0x1000000
+sf probe 0
+sf read 0x2000000 0x0 0x1000000
+mmc write 0x2000000 0x10 0x8000
+```
+
+Remove the card from the camera and insert it into a computer running Linux.
+Use `dd` command to copy data from the card to a binary file on the computer.
+
+```
+dd bs=512 skip=16 count=32768 if=/dev/sdc of=./fulldump.bin
+```
+
+### Bypassing password-protected bootloader.
+
+Changing the bootloader is a risky operation. There's a high probability of
+turning your camera into a paperweight if something goes wrong. So before you
+flash a new bootloader you have to weigh up all the risks and benefits. In most
+cases the original bootloader plus new kernel and new operating system should
+work just fine. But there are exceptions.
+
+Today, we see more and more cameras where access to bootloader console is
+protected with a password. Thus, even if you connect to the camera's UART port,
+all you will see after interrupting the standard boot cycle is a prompt for
+password. In that case, a relatively safe solution is to downgrade the firmware
+to a version where the password protection was not yet implemented. For example,
+for Xiongmai cameras the bootloader password protection started popping up
+somewhere around July 2021, hence you need a firmware for your camera from an
+earlier date. After you successfully downgrade your camera to a password-free
+bootloader, you could install the OpenIPC firmware in a regular way.

--- a/en/integration-kernel.md
+++ b/en/integration-kernel.md
@@ -1,5 +1,4 @@
 # OpenIPC Wiki
-
 [Table of Content](../index.md)
 
 Additional requirements for kernel configuration

--- a/en/integration-kernel.md
+++ b/en/integration-kernel.md
@@ -16,11 +16,19 @@ CONFIG_IP_PNP_DHCP=y
 CONFIG_ROOT_NFS=y
 ```
 
-## Patch files
+## Patch file requirements
 
-Patch files should be named `<number>-<description>.patch`.
-- The patch files should not contain any package version reference in their filename.
-- The field `<number>` in the patch file name refers to the apply order, and shall start at 1.
-It is preferred to pad the number with zeros up to 4 digits, like git-format-patch does. E.g.: _0001-foobar-the-buz.patch_
-- A message explaining what the patch does, and why it is needed, should be added in the header commentary of the patch.
-- You should add a Signed-off-by statement in the header of each patch to help with keeping track of the changes and to certify that the patch is released under the same license as the software that is modified.
+- Patch file name should follow format `<number>-<description>.patch`.
+
+- Patch file should not contain any reference to package version in its name.
+
+- The `<number>` part of patch's file name refers to the application order
+  starting from 1. It is preferred to left-pad the number with zeros up to total
+  of four digits, like `git-format-patch` does. _0001-foobar-the-buz.patch_
+
+- Patch file should contain a commentary in its header, explaining what this
+  patch does, and why it is needed.
+
+- Add a _Signed-off-by_ statement in the header of each patch file to help
+  tracking changes and certify that the patch is released under the same license
+  as the software it modifies.


### PR DESCRIPTION
We should keep markdown text narrow, as if typewrited on a list of paper, so it is suitable for reading on text-only terminals and for printing without rendering md files into html. And it's easier to make changes later from a tablet.