### PR TITLE
Update gpio-settings.md

### DIFF
--- a/en/gpio-settings.md
+++ b/en/gpio-settings.md
@@ -66,10 +66,11 @@ Tested on Gk7205v200:
 
 ### Jovision boards
 
-| Processor   | IRCUT1 | IRCUT2 | LIGHT |  TESTED BOARDS  |
-|-------------|--------|--------|-------|-----------------|
-| Hi3516Ev200 | 53     | 52     | 4     |                 |
-| Hi3516Cv100 | 42     | 43     | 6     | IPG5020A-H-V1.0 |
+| Processor   | IRCUT1 | IRCUT2 | LIGHT |  TESTED BOARDS    |
+|-------------|--------|--------|-------|-------------------|
+| Hi3516Ev200 | 53     | 52     | 4     |                   |
+| Hi3516Cv100 | 42     | 43     | 6     | IPG5020A-H-V1.0   |
+|             |        |        |       | 5013A-CF\5020A-FF |
 
 ### JUAN boards (Sannce)
 

--- a/en/gpio-settings.md
+++ b/en/gpio-settings.md
@@ -66,11 +66,10 @@ Tested on Gk7205v200:
 
 ### Jovision boards
 
-| Processor   | IRCUT1 | IRCUT2 | LIGHT |  TESTED BOARDS    |
-|-------------|--------|--------|-------|-------------------|
-| Hi3516Ev200 | 53     | 52     | 4     |                   |
-| Hi3516Cv100 | 42     | 43     | 6     | IPG5020A-H-V1.0   |
-|             |        |        |       | 5013A-CF\5020A-FF |
+| Processor   | IRCUT1 | IRCUT2 | LIGHT |  TESTED BOARDS                     |
+|-------------|--------|--------|-------|------------------------------------|
+| Hi3516Ev200 | 53     | 52     | 4     |                                    |
+| Hi3516Cv100 | 42     | 43     | 6     | IPG5020A-H-V1.0, 5013A-CF/5020A-FF |
 
 ### JUAN boards (Sannce)
 


### PR DESCRIPTION
испытал пины входа датчика освещения и шторки на плате jovision 5013A-CF\5020A-FF чип HI3516CV100 - работают