### PR TITLE
Add a note about network config in some weird cameras

### DIFF
--- a/en/network-perversions.md
+++ b/en/network-perversions.md
@@ -6,7 +6,7 @@ A collection of practical networking perversions
 
 
 ### XiongMai, HI3518EV100
-
+On some cameras it's required to do the U-boot network configuration to get it to work in Linux
 ```
 For U-boot network
     setenv phyaddru 1


### PR DESCRIPTION
I have a chinese noname camera (from aliexpress, bought a lot of time ago, can't find the listing). Ethernet wasn't working (no interface showing when executing `ip a`). For some reason the configuration for Linux didn't help, but the one for U-boot did. Pic of the board is attached
![image](https://github.com/OpenIPC/wiki/assets/85807099/ae9303d8-4dd9-472d-a86d-eddf5d04fb41)
