### PR TITLE
Translated FPV-extension wiki part

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ OpenIPC Wiki
 - [ACMEv2](en/acme-v2.md)
 - [YouTube streaming](en/youtube-streaming.md)
 - [WiFi XM530](en/wifi-xm530.md)
+- [For FPV](en/fpv.md)
+
 
 ### Troubleshooting
 - [Network does not work](en/trouble-network.md)

--- a/en/fpv-extension.md
+++ b/en/fpv-extension.md
@@ -1,0 +1,37 @@
+# OpenIPC Wiki
+[Table of contents](../README.md)
+
+Development of 38x38 expansion board for FPV systems
+--------------------------------
+
+Colleagues !
+
+Who flies and who held in his hands boards of standard 38x38 video cameras, send your wishes, based on real experience, on the expansion module for FPV. 
+Examples of homemade boards, that- to realize what we are talking about, you can see at the very bottom of the page (for other areas of OpenIPC use).
+
+
+### Formalization of requirements
+
+- dimensions and materials
+    - standard 38x38 expansion board used in video surveillance ("sandwich")
+    - double-sided glass-textolite, thickness (?)
+- interfaces
+    - pitch of all connectors 1.25, board mounting through metallized hole (NOT SMD!)
+    - connector type, jst-gh 1.25 or df13 1.25 or something else, optionally installed
+    - connector pins are duplicated with metallized holes for soldering wires
+- components
+    - external power supply for wifi whistle ~2-3A
+    - connectors (heels) for soldering under UART (flight controller)
+    - heels (connectors) for whistle connection
+    - additional heels (5-12) for suspension power supply
+    - indication of voltage presence by LEDs (?)
+
+### A selection of photos
+
+<p align="center">
+<img src="https://github.com/OpenIPC/wiki/blob/master/images/fpv-extension-old.jpg?raw=true" alt="Logo"/>
+</p>
+
+### References on the topic
+
+* https://oshwhub.com/libc0607/xm-ext-board-fpv

--- a/en/fpv.md
+++ b/en/fpv.md
@@ -323,7 +323,6 @@ Our team has extensive experience in low latency media transmission (some projec
 
 **Please use the translator, there is a lot of interesting stuff on FPV here:**
 
-- https://github.com/OpenIPC/wiki/blob/master/ru/fpv.md
 - https://github.com/openipc/sandbox-fpv
 - https://github.com/OpenIPC/silicon_research
 - [OpenIPC for building FPV systems, chat in telegram messenger](https://t.me/+BMyMoolVOpkzNWUy)


### PR DESCRIPTION
The link to the Russian article has been removed.
Added translation of FPV extension md.
Added link to EN FPV wiki to main readme