### PR TITLE
Fix minor error, "install-deps" -> "deps"

### DIFF
--- a/en/building.md
+++ b/en/building.md
@@ -18,7 +18,7 @@ cd openipc-firmware
 ### Install required packages.
 
 ```bash
-sudo make install-deps
+sudo make deps
 ```
 
 ### Create a permanent storage for downloaded bundles.


### PR DESCRIPTION
The makefile only has "deps" in it, not "install-deps"
![image](https://github.com/OpenIPC/wiki/assets/6174343/ff9cb064-c44b-4f6b-aa57-bb91de3f6085)
