### PR TITLE
Add * as possible key combo

### DIFF
--- a/en/installation.md
+++ b/en/installation.md
@@ -179,7 +179,7 @@ Reboot the camera and try to interrupt its boot sequence in order to access
 bootloader console by pressing a key combination on your computer keyboard,
 between the time the bootloader starts and before Linux kernel kicks in.
 Key combinations differ from vendor to vendor but, in most cases, it is
-`Ctrl-C`, less commonly -- `Enter`, `Esc` or just any key. Carefully read text
+`Ctrl-C`, less commonly -- `Enter`, `Esc`, `*` or just any key. Carefully read text
 appearing on screen while booting, you might see a hint there. Some cameras
 require more exotic combinations not revealed in booting logs. You may try to
 look them up on the internet, or ask on [our Telegram channel][telegram].


### PR DESCRIPTION
As described [here](https://ipcamtalk.com/threads/dahua-ipc-unbricking-recovery-over-serial-uart-and-tftp.16474/) in Dahua and Imou cameras "*" is a key that stops uboot and enables shell.