### PR TITLE
Sensor driver installation example

### DIFF
--- a/en/firmware-sensor-install-sc223a.md
+++ b/en/firmware-sensor-install-sc223a.md
@@ -9,6 +9,7 @@ You need a sensor library and one sensor configuration file.
 You can find the files for your sensor following [this list](https://github.com/OpenIPC/wiki/blob/master/en/firmware-sensors.md).
 
 As an example the image sensor "sc223a" will be installed to a gk7205v210 board ( with openipc-gk7205v210-fpv-8mb.bin flashed).
+
 Install the files by downloading them directly from github to your device:
 ```
 curl -s -L -o /usr/lib/sensors/libsns_sc223a.so https://github.com/OpenIPC/firmware/raw/master/general/package/goke-osdrv-gk7205v200/files/sensor/libsns_sc223a.so

--- a/en/firmware-sensor-install-sc223a.md
+++ b/en/firmware-sensor-install-sc223a.md
@@ -4,9 +4,10 @@
 Install Image Sensors
 -----------------------
 
-If your image sensor driver is not included in the firmware image, you can install it manually.
+If an image sensor driver is not included in the firmware image, you can install it manually.
+
 You need a sensor library and one sensor configuration file.
-You can find the files for your sensor following [this list](https://github.com/OpenIPC/wiki/blob/master/en/firmware-sensors.md).
+The files can be found following [this list](https://github.com/OpenIPC/wiki/blob/master/en/firmware-sensors.md).
 
 As an example the image sensor "sc223a" will be installed to a gk7205v210 board ( with openipc-gk7205v210-fpv-8mb.bin flashed).
 


### PR DESCRIPTION
This example shows how to install image sensor drivers.
Sc223a will be installed onto a gk7205v210 board.