### PR TITLE
(re)start majestic on terminal

### DIFF
--- a/en/firmware-sensor-install-sc223a.md
+++ b/en/firmware-sensor-install-sc223a.md
@@ -24,8 +24,9 @@ Search for "Isp_FrameRate" in file [/etc/sensors/sc223a_i2c_1080p.ini](https://g
 cli -s .video0.fps 30
 ```
 
-Restart streamer:
+(Re)start streamer:
 
 ```sh
-killall -1 majestic
+killall majestic
+majestic
 ```


### PR DESCRIPTION
1. If the sensor driver was not present at boot time it is most unlikely that majestic is running. So it can not receive the reload signal (SIGHUP from "killall -1").
2. When installing new sensor drivers and config you want to see the majestic log on terminal for debugging.