### PR TITLE
Yay. My camera works now. T31L/SC2336

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ OpenIPC Wiki
 ### Troubleshooting
 
 - [Network does not work](en/trouble-network.md)
-- [Majestic does not work, camera reboots](en/trouble-majestic.md)
+- [Majestic does not show images, no reboot](en/trouble-majestic.md#troubleshooting-majestic-does-not-show-any-images-no-reboot)
+- [Majestic does not work, camera reboots](en/trouble-majestic.md#troubleshooting-majestic-does-not-work-camera-reboots)
 - [Sigmastar unbrick instructions](en/sigmastar-unbrick.md)
 - [Ingenic T31 unbrick with SD card](en/ingenic-t31-unbrick-with-sd-card.md)
 

--- a/en/trouble-majestic.md
+++ b/en/trouble-majestic.md
@@ -1,6 +1,28 @@
 # OpenIPC Wiki
 [Table of Content](../README.md)
 
+## Troubleshooting: Majestic does not show any images, no reboot
+
+Let's say that `top` shows that majestic is running, but no image is displayed.
+The preview tab shows only a test pattern and there is an error similar to the
+one below in dmesg.
+
+```
+...
+sc2336 chip found @ 0x30 (i2c0)
+sensor driver version H20210805a
+sc2336 stream on
+error: one buffer schedule only support nrvbs = 1, chan index:0, num_buffers:2
+...
+```
+
+The `nrvbs = 1` may be the problem. Set the `isp.blkCnt` majestic property
+to 1 with the Block Count control on the ISP tab of Majestic settings, then
+restart majestic.
+This issue has only been documented on T31L and T31N SOCs with SC2336 and
+JXF37 sensors; let us know if you see this on a different platform an if this
+setting change works for you.
+
 ## Troubleshooting: Majestic does not work, camera reboots
 
 To troubleshoot majestic you first need to get access to its logs, right to the moment as it crashes, 


### PR DESCRIPTION
Thanks to https://github.com/OpenIPC/firmware/issues/759, it seems that my T31L also needs `isp.blkCnt=1`, let's document this so that others can find it.

It does appear that `package/ingenic-osdrv-t31/files/script/load_ingenic` should do this, I have no idea why it didn't do that on my camera. The tinkering continues.