### PR TITLE
Fixed pin numbers for SSC335

### DIFF
--- a/en/gpio-settings.md
+++ b/en/gpio-settings.md
@@ -9,7 +9,7 @@ Board specific GPIO settings list
 | Processor   | IRCUT1 | IRCUT2 | LIGHT | RESET | I/O | TESTED BOARDS    |  AUDIO OUTPUT   |
 |-------------|--------|--------|-------|-------|-----|------------------|-----------------|
 | SSC30KQ     | 23     | 24     | 60    | 10    |     | MC-L12, MC-L12B  |                 
-| SSC335      | 78     | 79     | 61    | 66    | 52  | MS-J10, YM200J10 |
+| SSC335      | 78     | 79     | 61/53 | 66    | 52  | MS-J10, YM200J10 |
 | SSC337      | 78     | 79     | 61    | 66    | 52  | MC-F40, YM-J10D  |
 | SSC337DE    | 78     | 79     | 61    | 66    |     | MC500L8          |
 | SSC338Q     | 23     | 24     | 60    | 10    |     | MC800S-V3        |      39         |


### PR DESCRIPTION
Added the correct pin for the MC-F26/SSC335 IR Light GPIO.