### PR TITLE
Remove SIGUSR1 mention from majestic-streamer.md

### DIFF
--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -15,7 +15,6 @@ Unneeded options can be switched off for better security and performance. See /e
 
 ```
 -HUP restart Majestic (Except Ingenic T21).
--SIGUSR1 fast reload (Sigmastar only).
 -SIGUSR2 SDK Shutdown (For all platforms).
 ```
 


### PR DESCRIPTION
As @widgetii said, SIGUSR1 is no more supported by Majestic.
Entire process hangs if used, and the device restarts if watchdog is enabled.