### PR TITLE
fix dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ OpenIPC Wiki
 ### Roadmap
 
 - [ToDo](en/todo-all.md)
-- [Developers](en/developers.md)
+- [Developers](en/contribute.md)
 - [Notes from old sources](en/notes-for-resorting.md)
 
 ### Reference Book


### PR DESCRIPTION
there is no file `developers.md` so a link to `contribute.md` was added instead