### PR TITLE
Created a new wiki article to explain setup of SSH using keys and no passwords

### DIFF
--- a/en/faq.md
+++ b/en/faq.md
@@ -105,6 +105,10 @@ For a camera with 16MB flash chip, run
 sf probe 0; sf erase 0xd50000 0x2b0000; reset
 ```
 
+### How to connect to camera with SSH using keys / no password 
+
+See seperate wiki page [here](en/sshusingkeys.md)
+
 ### How to find information about the camera hardware and software?
 
 Sign in on camera via `ssh` and run `ipctool`.
@@ -192,36 +196,6 @@ Make sure to use your own IP address and path to the NFS share!
 
 ```bash
 strings dumpfile.bin | grep ^ethaddr
-```
-
-### How to configure ssh session authorization by key
-
-__On the camera__: Sign in into web UI on port 85 of your camera.
-
-```bash
-passwd
-```
-
-__On the desktop__: Copy the public key to the camera by logging in with the
-password created above.
-
-```bash
-ssh-copy-id root@192.168.1.66
-```
-
-__On the camera__: Create a `.ssh` folder in the root user's home directory
-and copy the file with the authorized keystore into it.
-
-```bash
-mkdir ~/.ssh
-cp /etc/dropbear/authorized_keys ~/.ssh/
-```
-
-__On the desktop__: Open a new session to verify that the authorization is
-passed using the public key not requesting a password.
-
-```bash
-ssh root@192.168.1.66
 ```
 
 ### Majestic

--- a/en/sshusingkeys.md
+++ b/en/sshusingkeys.md
@@ -6,7 +6,7 @@ SSH access using public key authentication
 ## Introduction
 OpenIPC uses a package called Dropbear for managing **S**ecure **SH**ell (SSH) client connections. By default this is configured to use the root username and associated password however it can be made both more secure and simpler by making it passwordless.
 
-If you are new to understanding SSH and PKI then it is suggested you read one of the [many articles](https://www.ssh.com/academy/ssh) already written for a full understanding however unless you need to debug why connections are failing in detail the basic understanding of the terms client, server and keys should be sufficient as described here.
+If you are new to understanding SSH and PKI then it is suggested you read the ssh guide [here](https://www.ssh.com/academy/ssh) for a full understanding however unless you need to debug why connections are failing or some other in depth issue then the basic understanding of the terms client, server and keys should be sufficient.
 
 The term PKI is used to describe all of the elements used for creating a secure encrypted connection between two devices. These devices are referred to as clients or servers. In simple terms the target machine you are connecting to is the server and the host machine you are connecting from is the client.
 
@@ -23,15 +23,15 @@ There are a few things to watch out for to ensure a successful connection as the
 This article has been written on how to achieve this using the standard SSH clients included with most modern Linux and Windows distributions i.e. OpenSSH.
 
 ## OpenIPC camera with public key (most common setup)
-For the most common configuration, where we have the private key as described above, we first need to generate a key pair and securely get our key to the camera into the authorized_key file.
+For the most common configuration we first need to generate a key pair and securely get our key to the camera into the authorized_key file.
 
 #### Step 1: connect to the camera
-First we need to establish a terminal connection to the camera using the traditional way with your current root password (as per the Majestic web login) e.g. ``` ssh root@192.168.1.10 ```
+Establish a terminal connection to the camera using the traditional way with your current root password (as per the Majestic web login) e.g. ``` ssh root@192.168.1.10 ```
 
 #### Step 2: check there is a symlink to the dropbear files
 When using SSH there are two key files, authorized_keys and known_hosts, which are expected to be found in the users **.ssh** directory in both Windows and Linux systems. 
 
-As OpenIPC uses Dropbear, and not OpenSSH, these files are actually located in the /etc/dropbear directory and so on the camera there is a link created in the root user home directory (/root) that points to the required files and will look like this **.ssh -> /etc/dropbear/**. 
+As OpenIPC uses Dropbear, and not OpenSSH, these files are actually located in the **/etc/dropbear** directory and so on the camera there is a link created in the **root user home directory (/root)** that points to the required files and will look like this **.ssh -> /etc/dropbear/**. 
 
 If this is missing then it is critical to recreate it with the command **ln -s ~/.ssh /etc/dropbear**
 
@@ -44,7 +44,7 @@ To create the key pair on your **client** machine open a terminal window enter `
 
 You will be prompted with a few questions, simply press enter to accept the defaults.
 
-You should see an output similar to.
+You should see an output similar to this.
 
 ```Generating public/private ed25519 key pair.
 Enter file in which to save the key (/home/<yourusername>/.ssh/id_ed25519): 
@@ -74,7 +74,7 @@ If using windows then you will see /users/<yourusername> instead of the Linux /h
 So we now have a private key and the associated public key on our host machine and the challenge is how to securely get this onto our target, in this case our camera, and added to the authorized_keys file in the target .ssd folder.
 
 Thankfully this has been thought of and there is a utility called ssh-copy-id which allows us to do that.
-Enter the following:
+Enter the following substituting your camera ip address and username:
 ```
 ssh-copy-id -i /home/<yourusername>/.ssh/id_ed25519 root@<yourcameraip>
 
@@ -138,4 +138,4 @@ To get a clue how to resolve issues then when entering the ssh command add -vvv 
 
 
 #### Finally
-Remember the private key in your local host machine should never be duplicated or moved  Enjoy no more passwords to enter :-) 
+Remember the private key in your local host machine should never be duplicated or moved.

--- a/en/sshusingkeys.md
+++ b/en/sshusingkeys.md
@@ -24,7 +24,7 @@ This article has been written on how to achieve this using the standard SSH clie
 For the most common configuration we first need to generate a key pair and securely get our key to the camera into the authorized_key file.
 
 #### Step 1: connect to the camera
-Establish a terminal connection to the camera using the traditional way with your current root password (as per the Majestic web login) e.g. ``` ssh root@192.168.1.10 ```
+Establish a terminal connection to the camera using the traditional way with your current root password (as per the Majestic web login) e.g. ``` ssh root@<camera_ip_address> ```
 
 #### Step 2: check there is a symlink to the dropbear files
 When using SSH there are two key files, authorized_keys and known_hosts, which are expected to be found in the users home **.ssh** directory in both Windows and Linux systems. 
@@ -74,12 +74,12 @@ So we now have a private key and the associated public key on our host machine a
 Thankfully this has been thought of and there is a utility called ssh-copy-id which allows us to do that.
 Enter the following substituting your camera ip address and username:
 ```
-ssh-copy-id -i /home/<yourusername>/.ssh/id_ed25519 root@<yourcameraip>
+ssh-copy-id -i /home/<yourusername>/.ssh/id_ed25519 root@<camera_ip_address>
 
 ```
 
 You should get the following 
-```ssh-copy-id -i /home/<yourusername>/.ssh/id_ed25519 root@<yourcamipaddress>
+```ssh-copy-id -i /home/<yourusername>/.ssh/id_ed25519 root@<camera_ip_address>
 /usr/bin/ssh-copy-id: INFO: Source of key(s) to be installed: "/home/<yourusername>/.ssh/id_ed25519.pub"
 /usr/bin/ssh-copy-id: INFO: attempting to log in with the new key(s), to filter out any that are already installed
 /usr/bin/ssh-copy-id: INFO: 1 key(s) remain to be installed -- if you are prompted now it is to install the new keys
@@ -87,12 +87,12 @@ root@<yourcameraip>'s password:
 
 Number of key(s) added: 1
 
-Now try logging into the machine, with:   "ssh 'root@<yourcamipaddress>'"
+Now try logging into the machine, with:   "ssh 'root@<camera_ip_address>'"
 and check to make sure that only the key(s) you wanted were added.
 ```
 
 Now test it is working by trying to access the camera. You should find it will successfully login without asking for a password.
-```~$ ssh root@<yourcamipadddress>192.168.1.173
+```~$ ssh root@<camera_ip_address>
 
    .d88888b.                             8888888 8888888b.   .d8888b.
   d88P" "Y88b                              888   888   Y88b d88P  Y88b

--- a/en/sshusingkeys.md
+++ b/en/sshusingkeys.md
@@ -18,8 +18,6 @@ In the initial connection phase there is also a check that the server is the cor
 
 There are many algorithms that have been implemented over the years to ensure connections are extremely hard to break into and so with modern computing power this has meant some of the earlier ones are no longer supported. Modern popular public key encryption standards include RSA (Rivest–Shamir–Adleman) and EdDSA (Edwards-curve Digital Signature Algorithm).
 
-There are a few things to watch out for to ensure a successful connection as the security settings, for example, are crucial on the files and folders so ensure you follow the instructions step by step below.
-
 This article has been written on how to achieve this using the standard SSH clients included with most modern Linux and Windows distributions i.e. OpenSSH.
 
 ## OpenIPC camera with public key (most common setup)
@@ -29,9 +27,9 @@ For the most common configuration we first need to generate a key pair and secur
 Establish a terminal connection to the camera using the traditional way with your current root password (as per the Majestic web login) e.g. ``` ssh root@192.168.1.10 ```
 
 #### Step 2: check there is a symlink to the dropbear files
-When using SSH there are two key files, authorized_keys and known_hosts, which are expected to be found in the users **.ssh** directory in both Windows and Linux systems. 
+When using SSH there are two key files, authorized_keys and known_hosts, which are expected to be found in the users home **.ssh** directory in both Windows and Linux systems. 
 
-As OpenIPC uses Dropbear, and not OpenSSH, these files are actually located in the **/etc/dropbear** directory and so on the camera there is a link created in the **root user home directory (/root)** that points to the required files and will look like this **.ssh -> /etc/dropbear/**. 
+As OpenIPC uses Dropbear, and not OpenSSH, these files are actually located in the cameras **/etc/dropbear** directory and so there is a link in the **root user home directory (/root)** that points to the required files and will look like this **.ssh -> /etc/dropbear/**. 
 
 If this is missing then it is critical to recreate it with the command **ln -s ~/.ssh /etc/dropbear**
 
@@ -132,10 +130,9 @@ drwxr-xr-x    1 root     root             0 Oct  4 12:28 ..
 ####  Step 4: Troubleshooting
 There are few reasons why if you have followed the above that this will not work however the main issue faced is if for some reason the permissions are not correct on the .ssh folder and the files within it.
 
-Ensure the .ssh folder has 700 permissions and the authorized_keys file 600 or similar in Windows only your user and administrators have permission.  
+Ensure the .ssh folder has 700 permissions and the authorized_keys file 600 or similar in Windows, only your user and administrators have permission.  
 
 To get a clue how to resolve issues then when entering the ssh command add -vvv which gives verbose debug output and usually will highlight where things are failing.
 
-
 #### Finally
-Remember the private key in your local host machine should never be duplicated or moved.
+Remember the private key should never be duplicated or moved.

--- a/en/sshusingkeys.md
+++ b/en/sshusingkeys.md
@@ -1,0 +1,45 @@
+# OpenIPC Wiki
+[Table of Content](../README.md)
+
+SSH access using public key authentication
+==========================================
+In OpenIPC remote access via SSH is handled by the Dropbear module [see https://github.com/mkj/dropbear]
+
+To enable password free access and enhance security you can simply configure the required key details by completing the following steps:
+
+#### Step 1: connect to the camera
+First we need to establish a terminal connection to the camera using the traditional way with your current root password 
+e.g. ssh root@192.168.1.10. This is because we need to find the existing private key file so we can get the public key for our client end configuration. 
+
+#### Step 2: check there is a symlink to the dropbear files
+When using clients for remote login they look for two key files, authorized_keys and known_hosts, which reside in the users .ssh directory in both Windows and Linux systems. 
+In OpenIPC these files are actually located in the /etc/dropbear directory and so by default there is a link created in the root user home directory (/root) that points to the required files 
+and will look like this **.ssh -> /etc/dropbear/**
+
+If this has been deleted or changed in your camera then create it with the command **ln -s ~/.ssh /etc/dropbear**
+
+#### Step 3: get the public key
+There are two keys used in the public key authentication process a private key and a public key. As their names suggest the private key must be kept secure and not shared with anyone however the public key is what we want to get and use in the client end.
+
+By default dropbear creates a file named **dropbear_ed25519_host_key** with is located in the the **/etc/dropbear** directory and this is the private key.
+
+We need to use the dropbearkey tool to get the public key
+
+at the prompt enter dropbearkey -y -f /etc/dropbear/dropbear_ed25519_host_key
+
+This will display the public key which we need. Simply highlight the text on screen after the statement Public key portion is: and copy it to your clipboard or a text file for temporary storage.
+
+#### Step 4: configure your client
+On your client machine find your .ssh directory typically in the user home direcotry so on linux ~/.ssh or in windows the /users/yourloginnanme/.ssh
+
+Paste in the copied text on a single line and save the file
+
+#### Step 5: test the connection for no password challenge
+Now when you reconnect to the camera you should find that after a short delay that you are logged in without being asked for your password.
+
+If you connect to the camera from multiple clients then configure the clients as above.
+
+#### Trouble shooting
+SSH access is very strict about ensuring that the keys in use are protected and therefore secure so if the permissions on the directories and files are not correct this can cause failures
+
+To check what is going on and find any issues then use the -v option in ssh to get a verbose output


### PR DESCRIPTION
Although there was a section in the FAQ on how to get SSH setup for password less access it was out of date. 

So after working through how Dropbear is used for SSH I thought it was worth creating a new wiki article on how to set up the keys and to give people new to SSH a little background on what is needed and why.

Hopefully it will be of value to other people.

I updated the FAQ to point to this but have not added a specific link from the wiki menu.

