### PR TITLE
Deprecation of the Wiki and introduction of the Docs Website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+# 🚨 Deprecated Wiki 🚨
+
+This repository is no longer maintained and has been replaced by a new, more user-friendly documentation platform. 
+
+Explore the new OpenIPC documentation site here: 👉 [https://docs.openipc.org](https://docs.openipc.org)
+
+This marks a new era of openness and collaboration for OpenIPC, offering improved navigation and easier access to information.
+
+## 🛠 Contribution Guidelines
+
+Contribute to the new docs by following the guide here: 👉 [Contribution Guidelines](https://docs.openipc.org/development/contribution-guidelines/)
+
+We welcome contributions, from small fixes to full content additions!
+
+## 📅 Help Us Migrate Content
+
+We need your help to migrate important content from this wiki to the new platform. Let’s work together to ensure valuable information is transferred over.
+
+---
+
 OpenIPC Wiki
 ============
 


### PR DESCRIPTION
### 📄 Deprecation of Old Wiki

This is a PR to follow the deprecation process of the old wiki. The goal is to guide users to the new, improved documentation platform and encourage the migration of important content.

### Changes Made:
- Added a **Deprecation Notice** to the old wiki repository.
- Introduced the new OpenIPC documentation platform: 👉 [https://docs.openipc.org](https://docs.openipc.org)
- Included links to the new [Contribution Guidelines](https://docs.openipc.org/development/contribution-guidelines/) to help users contribute to the new platform.
- Called for community assistance in migrating valuable content from the old wiki to the new platform.

### Why This is Important:
- The new documentation site offers a more user-friendly experience with better navigation and access to information.
- This deprecation process ensures that no critical information is lost and encourages community collaboration in the migration process.

### ⚠️ Note:
Once this PR is merged, maintainers should **archive** this repository to make it read-only and officially mark it as deprecated.

