### PR TITLE
docs: migrate majestic config examples from yaml-cli to the HTTP API

### DIFF
--- a/en/device-foscam-x5.md
+++ b/en/device-foscam-x5.md
@@ -32,12 +32,20 @@ IRLed | IRCut | Speaker | Reset | IRSensor
 GPIO0 | GPIO3 | GPIO14 | GPIO66 | GPIO80
 
 ```
-cli -s .nightMode.irSensorPin 80
-cli -s .nightMode.irCutPin1 3
-cli -s .nightMode.irCutSingleInvert true
-cli -s .nightMode.backlightPin 0
-cli -s .audio.speakerPin 14
-cli -s .audio.speakerPinInvert true
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "nightMode": {
+    "irSensorPin": 80,
+    "irCutPin1": 3,
+    "irCutSingleInvert": true,
+    "backlightPin": 0
+  },
+  "audio": {
+    "speakerPin": 14,
+    "speakerPinInvert": true
+  }
+}
+EOF
 ```
 
 ---

--- a/en/device-tapo-c110.md
+++ b/en/device-tapo-c110.md
@@ -10,9 +10,17 @@ IRLed | WhiteLed | RedLed | GreenLed | Speaker | Reset | IRCut
 GPIO14 | GPIO15 | GPIO46 | GPIO47 | GPIO61 | GPIO66 | GPIO78
 
 ```
-cli -s .nightMode.irCutPin1 78
-cli -s .nightMode.backlightPin 14
-cli -s .audio.speakerPin 61
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "nightMode": {
+    "irCutPin1": 78,
+    "backlightPin": 14
+  },
+  "audio": {
+    "speakerPin": 61
+  }
+}
+EOF
 ```
 
 ---

--- a/en/firmware-sensor-install-sc223a.md
+++ b/en/firmware-sensor-install-sc223a.md
@@ -22,7 +22,7 @@ Adjust the fps value in /etc/majestic.yaml according to your sensor specs.
 Search for "Isp_FrameRate" in your sensor configuration file [/etc/sensors/sc223a_i2c_1080p.ini](https://github.com/OpenIPC/firmware/raw/master/general/package/goke-osdrv-gk7205v200/files/sensor/config/sc223a_i2c_1080p.ini).
 
 ```sh
-cli -s .video0.fps 30
+curl 'http://localhost/api/v1/set?video0.fps=30'
 ```
 
 (Re)start streamer:

--- a/en/fpv-audio.md
+++ b/en/fpv-audio.md
@@ -10,8 +10,15 @@ Video using OPUS 16000 OPUS samplerate: https://youtu.be/Z0KxSS24j7o
 ### Majestic and general settings
 Audio settings (majestic.yaml):
 ```
-cli -s .audio.enabled true
-cli -s .audio.srate 8000 (8000 pretty crap, 16000 usable and 48000 really good)
+# srate: 8000 pretty crap, 16000 usable, 48000 really good
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "audio": {
+    "enabled": true,
+    "srate": 8000
+  }
+}
+EOF
 ```
 
 ### Working sound, video & save to file

--- a/en/fpv-mavfwd.md
+++ b/en/fpv-mavfwd.md
@@ -14,7 +14,7 @@ peer = 'connect://127.0.0.1:14550'  # outgoing connection
 
 Update settings:
 ```
-echo cli -s .video0.fps 120 > /dev/udp/localhost/14550
+echo curl http://localhost/api/v1/set?video0.fps=120 > /dev/udp/localhost/14550
 ```
 
 Update drone key:

--- a/en/howto-frigate-integration.md
+++ b/en/howto-frigate-integration.md
@@ -141,8 +141,14 @@ otherwise eats CPU.
 ### 3a. Enable motion detection in Majestic
 
 ```sh
-cli -s .motionDetect.enabled true
-cli -s .motionDetect.debug true
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "motionDetect": {
+    "enabled": true,
+    "debug": true
+  }
+}
+EOF
 killall majestic; sleep 3; majestic &
 ```
 

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -41,15 +41,33 @@ The long JPEG control parameter did not fit into the example on the site and we 
 
 `/image.jpg?width=640&height=360&qfactor=73&color2gray=1`
 
-### Changing parameters via cli
+### Changing parameters via the HTTP API
 
-At the moment it is possible to change parameters in the configuration file via the CLI utility.
+Parameters can be changed at runtime through Majestic's HTTP API. Setting a
+value applies it to the running streamer and saves it to `/etc/majestic.yaml`
+in a single step — there is no need to reload or restart Majestic afterwards.
 
-This allows parameters to be changed with a single line in pseudo-dynamic mode on some platforms 
-simply by forcing a re-read of the configuration file.
+Set a single parameter (the key is the config path *without* the leading dot):
 ```
-cli -s .video0.codec h264 ; cli -s .video0.fps 10 ; killall -HUP majestic 
+curl 'http://localhost/api/v1/set?video0.fps=10'
 ```
+
+Set several parameters at once by posting a JSON document. Group the keys the
+same way they are nested in the config file:
+```
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "video0": {
+    "codec": "h264",
+    "fps": 10
+  }
+}
+EOF
+```
+
+> The older `cli` / `yaml-cli` utility (e.g. `cli -s .video0.fps 10 ; killall
+> -HUP majestic`) is deprecated. Prefer the HTTP API above, which applies the
+> change live and persists it for you.
 
 ### Experimental Control Features (not yet described in endpoints)
 
@@ -85,8 +103,14 @@ If the sensor gain is 1024 on a bright day the minThreshold could be set to 2000
 if the sensor gain is 32000 on a dark night the maxThreshold could be set to 10000.
 
 ```
-cli -s .nightMode.minThreshold 10
-cli -s .nightMode.maxThreshold 50
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "nightMode": {
+    "minThreshold": 10,
+    "maxThreshold": 50
+  }
+}
+EOF
 ```
 
 ### Motion detection
@@ -101,8 +125,14 @@ When a motion event is detected, `majestic` invokes a predefined script `/usr/sb
 Enable motion detection in `majestic` configuration:
 
 ```
-cli -s .motionDetect.enabled true
-cli -s .motionDetect.debug true
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "motionDetect": {
+    "enabled": true,
+    "debug": true
+  }
+}
+EOF
 ```
 
 Reboot the camera and restart `majestic` in the foreground:
@@ -122,11 +152,21 @@ You should see the script running after motion detection events:
 
 To instantly launch a YouTube broadcast, run these commands in the console:
 ```
-cli -s .video0.codec h264
-cli -s .audio.enabled true
-cli -s .outgoing.enabled true
-cli -s .outgoing.naluSize 1200
-cli -s .outgoing.server rtmp://a.rtmp.youtube.com/live2/you-key-here
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "video0": {
+    "codec": "h264"
+  },
+  "audio": {
+    "enabled": true
+  },
+  "outgoing": {
+    "enabled": true,
+    "naluSize": 1200,
+    "server": "rtmp://a.rtmp.youtube.com/live2/you-key-here"
+  }
+}
+EOF
 reboot
 ```
 
@@ -171,7 +211,7 @@ outgoing:
 For basic ONVIF to work correctly, you need to enable it and add a user to the system as shown in the example:
 
 ```
-cli -s .onvif.enabled true
+curl 'http://localhost/api/v1/set?onvif.enabled=true'
 adduser viewer -s /bin/false -D -H
 echo viewer:123456 | chpasswd
 ```

--- a/en/menu-index.md
+++ b/en/menu-index.md
@@ -42,7 +42,7 @@ We would be grateful for any feedback and suggestions.
 ### Tools
 
 * [ipctool](https://github.com/openipc/ipctool) - Tool (and library) for checking IP camera hardware.
-* [yaml-cli][yaml-cli] - Tool for change setting in CLI.
+* [yaml-cli][yaml-cli] - Tool for changing settings from the CLI (deprecated for Majestic; use the [HTTP API](majestic-streamer.md#changing-parameters-via-the-http-api) instead).
 * [glutinium](https://github.com/ZigFisher/Glutinium) - Additional OpenWRT packages.
 
 ### Windows software

--- a/ru/action-camera.md
+++ b/ru/action-camera.md
@@ -144,16 +144,28 @@ chmod +x /usr/bin/led_blink
 Эти же gpio прописываем в yaml'е:
 
 ```
-cli -s .nightMode.irCutPin1 14
-cli -s .nightMode.irCutPin2 15
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "nightMode": {
+    "irCutPin1": 14,
+    "irCutPin2": 15
+  }
+}
+EOF
 ```
 
 Включаем запись звука:
 
 ```
-cli -s .audio.enabled true
-cli -s .audio.srate 24000
-cli -s .audio.codec aac
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "audio": {
+    "enabled": true,
+    "srate": 24000,
+    "codec": "aac"
+  }
+}
+EOF
 ```
 
 Вставьте флэш-карточку в камеру и посмотрите, куда она смонтировалась:
@@ -165,9 +177,14 @@ mount | grep mnt
 Этот путь нужно указать в настройках стримера:
 
 ```
-cli -s .records.enabled true
-cli -s .records.path /mnt/mmcblk0p1/%Y-%m-%d-%H.mp4
-
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "records": {
+    "enabled": true,
+    "path": "/mnt/mmcblk0p1/%Y-%m-%d-%H.mp4"
+  }
+}
+EOF
 ```
 
 Теперь, после загрузки камеры, старые видео будут перемещаться в новую папку, а последний видеоролик лежать в корне флэшки.

--- a/ru/hiwatch-ds-i122.md
+++ b/ru/hiwatch-ds-i122.md
@@ -88,10 +88,16 @@ reset
 а переключение происходит только если закрыть сам объектив. Ни в стоковой, ни в РТ-шной прошивке следов **GPIO** датчика обнаружено не было, соответственно, либо это какой-то другой датчик, либо он фейковый.
 Отсюда следует, что переключать режим нужно скриптом. И для ручного и для автоматического переключения нужно настроить **GPIO** ИК-фильтра и подсветки. Это можно сделать либо в консоли, либо в веб-интерфейсе.
 ```
-cli -s .nightMode.enabled true
-cli -s .nightMode.irCutPin1 6
-cli -s .nightMode.irCutPin2 5
-cli -s .nightMode.backlightPin 42
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "nightMode": {
+    "enabled": true,
+    "irCutPin1": 6,
+    "irCutPin2": 5,
+    "backlightPin": 42
+  }
+}
+EOF
 ```
 
 ### Облако IPEye

--- a/ru/rostelecom-ipc-hdw1230sp_v3.md
+++ b/ru/rostelecom-ipc-hdw1230sp_v3.md
@@ -46,17 +46,25 @@ reset
 Логинимся под пользователем root с паролем 12345 и присутпаем к конфигурированию. Сенсор определяется автоматчески а натсроить нужно
 только переключение режима день/ночь и микрофон.
 ```
-cli -s .nightMode.irCutPin1 79
-cli -s .nightMode.irCutPin2 78
-cli -s .nightMode.backlightPin 52
-cli -s .nightMode.lightSensorPin 80
-cli -s .nightMode.lightSensorInvert true
-cli -s .nightMode.lightMonitor true
-cli -s .nightMode.colorToGray true
-cli -s .audio.enabled true
-cli -s .audio.codec aac
-cli -s .audio.srate 48000
-cli -s .audio.inputChannel 1
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "nightMode": {
+    "irCutPin1": 79,
+    "irCutPin2": 78,
+    "backlightPin": 52,
+    "lightSensorPin": 80,
+    "lightSensorInvert": true,
+    "lightMonitor": true,
+    "colorToGray": true
+  },
+  "audio": {
+    "enabled": true,
+    "codec": "aac",
+    "srate": 48000,
+    "inputChannel": 1
+  }
+}
+EOF
 reboot
 ```
 После перезапуска можно увидеть в консоли, какой адрес получит камера и зайти по нему в браузере. Если не получилось увидеть, то нужно снова залогиниться и ввести команду ifconfig eth0.


### PR DESCRIPTION
## Summary

Migrates every Majestic configuration example in the wiki from the deprecated `cli` / `yaml-cli` file-editing tool to Majestic's HTTP API. The API applies a change to the running streamer **and** saves it to `/etc/majestic.yaml` in a single step, so the old `killall -HUP majestic` reload step is no longer needed.

## Conventions used

- **Single setting** → `curl 'http://localhost/api/v1/set?key=value'` (dotted key, no leading dot)
- **Multiple settings** → a pretty-printed JSON document POSTed to `/api/v1/config` via a `<<'EOF'` heredoc, grouped the same way the keys nest in the config file

The old `cli` / `yaml-cli` idiom is called out as deprecated in `majestic-streamer.md` and the tools index.

## Verified on hardware

Ran the exact heredoc idiom on a hi3516ev300 (BusyBox v1.36.1 `ash`, curl 7.76.0):

- `POST /api/v1/config` with a JSON body → applied live and persisted to `/etc/majestic.yaml`
- the quoted `<<'EOF'` delimiter preserves `%`, `$`, and backticks literally, so `%Y`-style record paths round-trip byte-for-byte

## Files

`majestic-streamer`, `fpv-audio`, `fpv-mavfwd`, `howto-frigate-integration`, `device-foscam-x5`, `device-tapo-c110`, `firmware-sensor-install-sc223a`, `menu-index`, and the Russian `action-camera`, `hiwatch-ds-i122`, `rostelecom-ipc-hdw1230sp_v3` guides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)