### PR TITLE
majestic: fix outgoing YAML example, document audio codec/source changes

### DIFF
--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -72,7 +72,7 @@ osd:
 
 audio:
   enabled: false
-  volume: 30
+  volume: 30                                              # 0 mutes the input
   srate: 8000
   codec: opus
   outputEnabled: false
@@ -116,9 +116,15 @@ outgoing:
   enabled: false
   #server: udp://192.168.1.10:5600
   #naluSize: 1200
-  #- udp://IP:port                                        # Multiple data sending is configured only in the /etc/majestic.yaml file and is not available for control from the WebUI
-  #- unix:/tmp/rtpstream.sock
-  #- rtmps://dc4-1.rtmp.t.me/s/mykey
+  #audioCodec: ""                                         # RTMP audio codec (aac|alaw|ulaw|pcm); empty follows audio.codec
+  #audioSource: auto                                      # auto|mic|silence|file|none; silence/file feed a track when there is no microphone
+  #audioFile: ""                                          # ADTS .aac looped when audioSource is file
+  # Several destinations (majestic.yaml only, not available in the WebUI). Each
+  # entry is its own connection: udp/unix as RTP, rtmp/rtmps as RTMP.
+  #servers:
+  #  - udp://IP:port
+  #  - unix:/tmp/rtpstream.sock
+  #  - rtmps://dc4-1.rtmp.t.me/s/mykey
 
 watchdog:
   enabled: true
@@ -132,10 +138,6 @@ onvif:
 
 ipeye:
   enabled: false
-
-youtube:                                                  # This function only works with the external daemon plugin for Majestic
-  enabled: false
-  #key: xxxx-xxxx-xxxx-xxxx-xxxx
 
 netip:
   enabled: false

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -182,6 +182,29 @@ Examples of other addresses for different services:
 
 Important ! Many RTMP services will only work if audio streaming is enabled, so be careful.
 
+The outgoing stream sends an audio codec the RTMP container supports, converting
+from `audio.codec` when needed, so `audio.codec` can stay on Opus for RTSP while
+the broadcast still carries audio a service accepts. To pin a specific codec set
+`outgoing.audioCodec` (`aac`, `alaw`, `ulaw`, `pcm`); leave it empty to follow
+`audio.codec`. For A-law and mu-law the RTMP container is fixed at 8 kHz, so set
+`audio.srate: 8000` or the audio plays back at the wrong speed.
+
+If the camera has no microphone, `outgoing.audioSource` supplies a track anyway:
+
+```
+outgoing:
+  audioSource: auto     # auto | mic | silence | file | none
+  audioFile: ""         # path to an ADTS .aac file to loop
+```
+
+`auto` (the default) uses the microphone when there is one and otherwise sends a
+built-in silent track to services that require audio — including YouTube — so a
+mic-less camera streams there without enabling audio at all, and nothing changes
+for other destinations. `silence` forces the silent track everywhere; `file`
+loops audio you supply instead (create one with
+`ffmpeg -i music.mp3 -c:a aac -f adts loop.aac`; keep it under a megabyte, it is
+held in RAM); `none` sends no audio.
+
 We ask that you add information about other popular services here, thank you.
 
 RTMP reconnection and timeout logic works as follows:
@@ -195,16 +218,32 @@ RTMP reconnection and timeout logic works as follows:
 
 ### Other outgoing options
 
+A single destination is set with `server`:
+
 ```
 outgoing:
   enabled: true
-  server: udp://192.168.1.10:5600
   naluSize: 1200
-  - udp://IP-1:port
-  - udp://IP-2:port
-  - unix:/tmp/rtpstream.sock
-  - rtmps://dc4-1.rtmp.t.me/s/mykey
+  server: udp://192.168.1.10:5600
 ```
+
+For several destinations, list them under `servers` (this key is only read from
+`/etc/majestic.yaml`, it is not exposed in the WebUI). Every entry is started as
+its own connection: `udp://` and `unix:` endpoints are sent as RTP, `rtmp://`
+and `rtmps://` as RTMP.
+
+```
+outgoing:
+  enabled: true
+  naluSize: 1200
+  servers:
+    - udp://IP-1:port
+    - udp://IP-2:port
+    - unix:/tmp/rtpstream.sock
+    - rtmps://dc4-1.rtmp.t.me/s/mykey
+```
+
+If both `server` and `servers` are present, they are combined.
 
 ### ONVIF
 


### PR DESCRIPTION
Corrects the invalid YAML in the streamer doc and brings the config reference up to the majestic release landing now.

## Fixes reported in OpenIPC/majestic#209

The **Other outgoing options** example was not valid YAML — a mapping with loose `- item` entries under it, which no YAML parser accepts:

```yaml
outgoing:
  enabled: true
  server: udp://192.168.1.10:5600
  naluSize: 1200
  - udp://IP-1:port          # <- invalid: sequence items under a mapping
  - unix:/tmp/rtpstream.sock
```

Multiple destinations belong under a `servers:` list. Each entry is started as its own connection — `udp://` / `unix:` as RTP, `rtmp://` / `rtmps://` as RTMP — and `server` (singular) stays the shorthand for one destination, combined with `servers` if both are present. The reference config (`majestic-config.md`) carried the same broken shape in its commented block and is fixed the same way.

## Documents changes in the release landing tonight

- `audio.volume: 0` now mutes the input.
- `outgoing.audioCodec` pins the RTMP audio codec — `aac` / `alaw` / `ulaw` / `pcm`, empty to follow `audio.codec` (requested in OpenIPC/majestic#221). Includes the FLV 8 kHz caveat for G.711.
- `outgoing.audioSource` / `outgoing.audioFile` feed a built-in silent track, or an operator-supplied loop, so a camera with no microphone can stream to services that require audio — including YouTube (OpenIPC/majestic#291).
- Removed the `youtube:` block from the reference config: those keys no longer exist and never had a working upload path.

## Validation

Every YAML block in the changed sections was checked with a parser, including the commented reference-config lines once uncommented.

Merge once the release is published so the docs and the firmware line up.