### PR TITLE
docs: config keys majestic renamed away in 2024, and an unsupported srate

### DIFF
--- a/en/device-foscam-x5.md
+++ b/en/device-foscam-x5.md
@@ -35,7 +35,7 @@ GPIO0 | GPIO3 | GPIO14 | GPIO66 | GPIO80
 curl http://localhost/api/v1/config --data-binary @- <<'EOF'
 {
   "nightMode": {
-    "irSensorPin": 80,
+    "lightSensorPin": 80,
     "irCutPin1": 3,
     "irCutSingleInvert": true,
     "backlightPin": 0

--- a/en/device-smartwares-cip-37210.md
+++ b/en/device-smartwares-cip-37210.md
@@ -241,9 +241,8 @@ audio:
   speakerPin: 51
   speakerPinInvert: true
 nightMode:
-  enabled: true
-  irSensorPin: 62
-  irSensorPinInvert: true
+  lightSensorPin: 62
+  lightSensorInvert: true
   irCutPin1: 64
   backlightPin: 63
   dncDelay: 30

--- a/en/gpio-settings.md
+++ b/en/gpio-settings.md
@@ -236,7 +236,7 @@ Tested on GK7205V300 for /dev/ttyАМА1:
 > IRCUT1 is an irCutPin1<br>
 > IRCUT2 is an irCutPin2<br>
 > IRCTL is a backlightPin<br>
-> IRSTATUS is an irSensorPin
+> IRSTATUS is a lightSensorPin
 
 [^1]: 00014914 firmware
 [^2]: 00014911 firmware

--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -95,7 +95,7 @@ nightMode:
   #minThreshold: 2000
   #maxThreshold: 5000
   #lightSensorPin: 62
-  lightSensorPinInvert: false
+  lightSensorInvert: false
   #dncDelay: 30
 
 motionDetect:

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -93,7 +93,7 @@ root@openipc-ssc377d:~# wget -q -O - http://localhost/night/toggle
 ### Auto day/night detection
 
 If these variables are used, it is possible to replace the used sandbox scripts.
-Works only for simple day/night schemes with minimal configuration and in the absence of mentions of irSensorPin in the majestic.yaml configuration file.
+Works only for simple day/night schemes with minimal configuration and in the absence of mentions of lightSensorPin in the majestic.yaml configuration file.
 If the light sensor gpio is set, it will use the default mode.
 
 The settings work like this:

--- a/ru/action-camera.md
+++ b/ru/action-camera.md
@@ -161,7 +161,7 @@ curl http://localhost/api/v1/config --data-binary @- <<'EOF'
 {
   "audio": {
     "enabled": true,
-    "srate": 24000,
+    "srate": 48000,
     "codec": "aac"
   }
 }

--- a/ru/hiwatch-ds-i122.md
+++ b/ru/hiwatch-ds-i122.md
@@ -91,7 +91,6 @@ reset
 curl http://localhost/api/v1/config --data-binary @- <<'EOF'
 {
   "nightMode": {
-    "enabled": true,
     "irCutPin1": 6,
     "irCutPin2": 5,
     "backlightPin": 42


### PR DESCRIPTION
Found while checking every majestic config value in the wiki against a camera's live schema — extracted every `?key=value` from `api/v1/set` examples and every leaf from every `POST /api/v1/config` body, then validated each against `config.schema.json`.

## Keys majestic renamed away in 2024

`nightMode.irSensorPin` became `lightSensorPin`, and `irSensorPinInvert` became `lightSensorInvert`, in April 2024. `nightMode.enabled` went a month before that. Four pages still name them.

**This is not cosmetic on the two pages that POST them.** The config API rejects a key it does not know, and the batch handler stops at the first rejected leaf without applying the rest:

- `device-foscam-x5` leads its body with `irSensorPin`, so the irCut pins, `irCutSingleInvert` and the entire `audio` block behind it never get set
- `hiwatch-ds-i122` leads with `nightMode.enabled`, so its irCut and backlight pins never get set either

Both read as a working one-shot setup and neither does anything. Verified against a camera:

```
?nightMode.irSensorPin=80   -> HTTP 404
?nightMode.enabled=true     -> HTTP 404
?nightMode.lightSensorPin=1 -> HTTP 200
```

Renamed the two keys. Dropped `nightMode.enabled` rather than guessing a replacement — it gated something that no longer exists, and the GPIO pins are what those bodies are actually for. Anyone wanting the light monitor now asks for `lightMonitor` explicitly.

The smartwares page and the GPIO pin table name `irSensorPin` in YAML and prose, where it is silently ignored rather than rejected. Renamed for the same reason.

## An audio sample rate that was never supported

`action-camera` asks for `audio.srate: 24000`. Majestic accepts `8000`, `16000`, `32000` or `48000` — 24000 is not on that list and never has been, so this request has always failed:

```
?audio.srate=24000 -> HTTP 400
?audio.srate=16000 -> HTTP 200
```

Changed to `48000`, matching the other AAC example in the wiki (`rostelecom-ipc-hdw1230sp_v3`).

## Everything else checks out

Every other `?key=value` and every other value in a POST body across the wiki validates — enums, ranges and booleans all clean, including `video0.fps=120` sitting exactly on its declared maximum.

## Two left alone deliberately

`nightMode.dncDelay` and `nightMode.nightAPI` in the smartwares YAML block are not majestic keys either, but unlike the ones above they have no history in majestic at all, so I could not work out what they were meant to map to. They sit in a YAML block where an unknown key is ignored rather than rejected, so they break nothing. Flagging rather than deleting them — someone who knows that device should decide.
