### PR TITLE
majestic-streamer: goke does speaker output too, and spell hisilicon right

### DIFF
--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -310,7 +310,7 @@ Many boards gate the amplifier behind a GPIO. Set `audio.speakerPin` (and
 `audio.speakerPinInvert` if it is active-low), otherwise the logs look clean and
 nothing comes out.
 
-Speaker output is available on HiSilicon, Ingenic, Sigmastar, Allwinner,
+Speaker output is available on HiSilicon/Goke, Ingenic, Sigmastar, Allwinner,
 Rockchip and Xiongmai. `audio.srate` is shared by input and output; there is no
 separate output rate.
 

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -115,7 +115,7 @@ EOF
 
 ### Motion detection
 
-Motion detect is supported for Hisilion/Goke, Ingenic and Sigmastar.
+Motion detect is supported for HiSilicon/Goke, Ingenic and Sigmastar.
 When a motion event is detected, `majestic` invokes a predefined script `/usr/sbin/motion.sh` with a parameter specifying the object count:
 
 ```


### PR DESCRIPTION
## Summary

Two corrections to platform names in `en/majestic-streamer.md`.

**1. Goke was missing from the speaker-output platform list.** The "Two-way audio (talkback)" section listed the platforms with working speaker output as HiSilicon, Ingenic, Sigmastar, Allwinner, Rockchip and Xiongmai. Goke speaker output is supported, so the omission is a documentation bug.

**2. "Hisilion" typo.** The motion-detection line read `Hisilion/Goke`.

## Why it matters

The first one has a real cost. The reporter of OpenIPC/firmware#2183 wanted to play audio from a go2rtc server on a gk7205v200 speaker and went looking for third-party baresip modules (`goke.so`, `audio_source rtspausrc`) to do it — modules that exist in no OpenIPC repo and in no upstream baresip release. Majestic's `rtsp.backchannel` already covers that use case, but the docs read as though Goke was not among the platforms it works on.

## Fix

- `en/majestic-streamer.md:313` — `HiSilicon` → `HiSilicon/Goke`, matching the pairing the motion-detect line at `:118` and `en/howto-frigate-integration.md:136` already use.
- `en/majestic-streamer.md:118` — `Hisilion` → `HiSilicon`.

## Verification

- `en/majestic-streamer.md:313` is the only place in `en/` and `ru/` that enumerates the speaker-output platforms — checked by grepping for the neighbouring platform names; no other copy of the list exists.
- `Hisilion` occurs exactly once across `en/` and `ru/`. The separate lowercase-s variant `Hisilicon` is far more widespread (19 occurrences) and is deliberately left alone here: several are verbatim kernel log output (`en/device-chacon-ipcam-ri01.md`) or package paths in URLs, so that cleanup needs its own pass.
- `Goke` is already an established term in the wiki (`en/help-uboot.md:360`), so no spell-check dictionary change is needed.
