### PR TITLE
docs: the D-state commands missed threads whose names contain spaces

### DIFF
--- a/en/trouble-load-average.md
+++ b/en/trouble-load-average.md
@@ -63,7 +63,7 @@ They are not stuck and they are not busy — they simply spend the gap between
 frames in the one sleep state that the load average counts.
 
 On an SSC30KQ (Infinity6E) with one video channel and JPEG snapshots enabled,
-these twelve threads are permanently in `D`:
+and with OSD and audio both off, these twelve threads are permanently in `D`:
 
 | Thread | Waiting in |
 | --- | --- |
@@ -74,8 +74,19 @@ these twelve threads are permanently in `D`:
 | `mi_log` | `msleep` |
 | `ehci_monitor` | `msleep` |
 
-Twelve threads in `D` → a load average that settles at just over 12. Enabling
-audio adds a thirteenth (`ai0_P0_MAIN`) and the load settles at just over 13.
+Twelve threads in `D` → a load average that settles at just over 12.
+
+Enabling a feature that opens another SDK module adds its thread and moves the
+floor up by one. Two measured on the same camera:
+
+| Enabling | Adds the thread | Floor becomes |
+| --- | --- | --- |
+| `audio.enabled` | `ai0_P0_MAIN` | ~13 |
+| `osd.enabled` | `RGN BUF WQ` (waiting in `_mi_rgn_drv_buf_work_thread`) | ~13 |
+
+Enabling a second *video channel*, by contrast, adds nothing — `venc1_P0_MAIN`
+already exists for the JPEG encoder, and the vpe ports are fixed. So the floor
+tracks which SDK modules are in use, not how much work the camera is doing.
 
 Note that `msleep()` in the Linux kernel is uninterruptible by definition, so
 any driver thread that polls in a `msleep()` loop contributes to the load
@@ -130,7 +141,7 @@ Load average: 12.38 12.33 12.29 1/79 2458
 
 ```
 for t in /proc/[0-9]*/task/[0-9]*; do
-    [ "$(awk '{print $3}' "$t/stat" 2>/dev/null)" = "D" ] && \
+    [ "$(awk '/^State:/{print $2}' "$t/status" 2>/dev/null)" = "D" ] && \
         echo "$(cat "$t/comm")  <-  $(cat "$t/wchan")"
 done
 ```
@@ -145,13 +156,21 @@ venc0_P0_MAIN    <-  mi_sys_internal_main_worker_thread
 Every entry is a kernel thread from the vendor SDK, and their count matches the
 load average.
 
+These commands read the state from `/proc/<tid>/status` rather than from
+`/proc/<tid>/stat`, and that detail matters. In `stat` the format is
+`pid (comm) state …`, and a kernel thread's name may contain spaces — this SDK
+has one called `RGN BUF WQ` — so splitting `stat` on whitespace and taking the
+third field returns part of the *name* instead of the state, and silently drops
+exactly the threads it is looking for. `status` puts the state on its own
+`State:` line, where nothing can shift it.
+
 Save that list. It is your camera's baseline, and comparing against it is the
 only dependable way to tell a newly stuck task from the vendor's permanent
 ones:
 
 ```
 for t in /proc/[0-9]*/task/[0-9]*; do
-    [ "$(awk '{print $3}' "$t/stat" 2>/dev/null)" = "D" ] && cat "$t/comm"
+    [ "$(awk '/^State:/{print $2}' "$t/status" 2>/dev/null)" = "D" ] && cat "$t/comm"
 done | sort > /tmp/loadavg-baseline
 ```
 
@@ -238,7 +257,7 @@ baseline you saved earlier:
 
 ```
 for t in /proc/[0-9]*/task/[0-9]*; do
-    [ "$(awk '{print $3}' "$t/stat" 2>/dev/null)" = "D" ] && cat "$t/comm"
+    [ "$(awk '/^State:/{print $2}' "$t/status" 2>/dev/null)" = "D" ] && cat "$t/comm"
 done | sort | diff /tmp/loadavg-baseline -
 ```
 


### PR DESCRIPTION
Follow-up to #490, prompted by the original field report ([majestic-webui#180](https://github.com/OpenIPC/majestic-webui/issues/180)).

## The report didn't match the article

The reporter's `top` shows thirteen D-state threads and a load average of 13.23 — but **with `audio.enabled: false`**, so the thirteenth could not be the `ai0_P0_MAIN` the article blamed. Their extra thread is `RGN BUF WQ`, from the region/OSD module, which they have enabled and I did not.

## Reproducing it found a bug in the published commands

`/proc/<tid>/stat` is formatted `pid (comm) state …`, and a kernel thread name may contain spaces. `RGN BUF WQ` is one. So `awk '{print $3}'` returns `BUF` — part of the name — instead of the state, and the command silently drops exactly the threads it is hunting for.

Measured on an SSC30KQ with OSD on, the old and new commands side by side:

```
old (published)  = 12 : VEP_DumpTaskThr ehci_monitor mi_log venc0_P0_MAIN … vpe0_P3_MAIN
new (this PR)    = 13 : RGN BUF WQ VEP_DumpTaskThr ehci_monitor mi_log venc0_P0_MAIN … vpe0_P3_MAIN
loadavg          = 13.26
```

The published command reported twelve while the load average sat at 13.26 — the missing thread was the whole explanation. That also makes the baseline-diff diagnostic added in #490 unsound for any camera with OSD enabled, which is a common configuration.

Fixed by reading `State:` from `/proc/<tid>/status`, where nothing can shift the field, in all three commands. The article now says why, so the shortcut doesn't get reintroduced.

## Also

`"enabling audio adds a thirteenth"` is replaced by a table of both measured cases, because the point is that the floor tracks **which SDK modules are open**, not any one feature:

| Enabling | Adds the thread | Floor becomes |
| --- | --- | --- |
| `audio.enabled` | `ai0_P0_MAIN` | ~13 |
| `osd.enabled` | `RGN BUF WQ` (waiting in `_mi_rgn_drv_buf_work_thread`) | ~13 |

And a second *video channel* adds nothing — `venc1_P0_MAIN` already exists for the JPEG encoder and the vpe ports are fixed. This is the review point from #490 about the floor being device-specific, now with a second worked example instead of an assertion.

## Verification

All three commands re-run on an SSC30KQ with OSD enabled, extracted programmatically from the article so what was tested is exactly what is published:

- listing shows `RGN BUF WQ  <-  _mi_rgn_drv_buf_work_thread`
- baseline captures 13 lines
- unchanged diff is silent, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQXuiLPei8LC4r9S3j9KU2