### PR TITLE
docs: point endpoint questions at the camera, not at the website

### DIFF
--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -35,9 +35,14 @@ adduser viewer -s /bin/false -D -H ; echo viewer:123456 | chpasswd
 ### Camera related URLs in firmware
 
 Majestic supports multiple audio, video and still image formats, and more.
-You can find the full list of available endpoints on [this page](https://openipc.org/majestic-endpoints).
+The full list of endpoints is on the **Majestic Endpoints** page of the camera's
+own web interface: open `http://<camera-address>/` in a browser and pick it from
+the menu. That page is built from the firmware that is actually running, so it
+matches your build rather than whatever was current when a document was written.
+It also fills in the camera's own address, uses the right scheme for your setup
+(http or https, ws or wss), and says whether the endpoints ask for a password.
 
-The long JPEG control parameter did not fit into the example on the site and we publish it here:
+A JPEG snapshot takes control parameters, for example:
 
 `/image.jpg?width=640&height=360&qfactor=73&color2gray=1`
 

--- a/en/menu-index.md
+++ b/en/menu-index.md
@@ -36,7 +36,7 @@ We would be grateful for any feedback and suggestions.
 
 ### Streamers
 
-* [majestic](https://openipc.org/majestic-endpoints) - Universal IPCam streamer.
+* [majestic][majestic] - Universal IPCam streamer.
 * [mini][mini] - OpenSource Mini IP camera streamer.
 
 ### Tools


### PR DESCRIPTION
Companion to OpenIPC/website#102, which stops `/majestic-endpoints` from
carrying its own copy of the endpoint list.

Two files linked into that page:

- `en/majestic-streamer.md:38` — "You can find the full list of available
  endpoints on [this page]"
- `en/menu-index.md:39` — the Streamers entry for majestic

The list they pointed at had fallen behind the firmware: no `/ws/video` (the
low-latency fMP4 stream the WebUI's own Preview uses), no `/nwebrtc`, no
`/api/v1/config.schema.json`, no `/night/ircut` or `/night/light`, no
`/image.webp`, no `rtsp://…/stream=2`. The camera's own WebUI has a **Majestic
Endpoints** page built from the running firmware, which additionally fills in
the camera's real address, uses the right scheme, and says whether the
endpoints ask for a password.

So `majestic-streamer.md` now names that page and says why it is the one to
trust. The sentence about the long JPEG parameter "not fitting into the example
on the site" referred to the website page's layout, which no longer exists —
the parameters stay, the excuse goes.

`menu-index.md` already defines `[majestic]: https://github.com/OpenIPC/majestic`
at the bottom, and every other entry in that list uses its reference; this one
was the odd inline URL out.

cspell clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Uo5RmXBdnWHT55pvant4q