### PR TITLE
docs: tell Hi3518EV200 owners to check DDR2 vs DDR3 before flashing

### DIFF
--- a/en/install-hisi.md
+++ b/en/install-hisi.md
@@ -58,6 +58,36 @@ understand what you do.
 NB! Replace bootloader filename with the one matching your SoC. 
 Full list is [here](https://github.com/OpenIPC/firmware/releases/tag/latest).
 
+#### Hi3518EV200: check whether your board is DDR2 or DDR3 first
+
+This SoC ships with either kind of memory and the two bootloaders are not
+interchangeable — the DRAM type is fixed in a register table inside the image,
+so the wrong one leaves the board with no working memory at all. It flashes
+and verifies perfectly and then boots nothing, which looks like a bad flash
+and is not one.
+
+Read the memory controller from any working HiSilicon U-Boot prompt — the
+vendor's own bootloader will do, you do not need OpenIPC running yet:
+
+```
+hisilicon # md.l 0x20111050 1
+20111050: 00000016    ....
+```
+
+The last hex digit is the DRAM type:
+
+| last digit | memory | bootloader to flash |
+|---|---|---|
+| `5` | DDR2 | `u-boot-hi3518ev200-universal.bin` |
+| `6` | DDR3 | `u-boot-hi3518ev200-ddr3-universal.bin` |
+
+Do not tell the two apart by file size or checksum — the build embeds a
+timestamp, so those change between builds of identical sources.
+
+The `-recovery.bin` images are a different thing again: they are built to fit
+the boot ROM's SRAM window so they can be uploaded over UART to a board that
+will not boot at all. Do not flash them.
+
 ```
 mw.b 0x42000000 ff 1000000
 tftp 0x42000000 u-boot-hi3516xxxxx-beta.bin


### PR DESCRIPTION
Follow-up to OpenIPC/u-boot-hi3516cv200#9, which started publishing
`u-boot-hi3518ev200-ddr3-{universal,recovery}.bin`.

Hi3518EV200 boards ship with either DDR2 or DDR3, and the bootloaders are
not interchangeable — the DRAM type is fixed in a register table baked
into the image, so the wrong one leaves the board with no working memory
at all. The failure is nasty precisely because it looks like something
else: the flash writes and verifies byte-for-byte, and then nothing
boots.

In OpenIPC/firmware#2299 that cost the reporter about a week, a UART
recovery session and a register dump out of their vendor bootloader
before we worked out that the board was DDR3 and every OpenIPC
hi3518ev200 image was DDR2.

`md.l 0x20111050 1` from any working HiSilicon U-Boot — including the
vendor's own, before OpenIPC is installed — answers it in one command:
the last hex digit is `5` for DDR2 and `6` for DDR3, per
`DMC_CFG_DRAM_TYPE_MASK` in `drivers/ddr/ddr_ddrc_v500.h`. This puts that
check immediately before the bootloader-flashing commands in the Danger
zone section.

Two other things it says, both learned the hard way in that issue:

- **Do not identify the images by size or checksum.** The U-Boot build
  generates `U_BOOT_DATE`/`U_BOOT_TIME` from `date`, so the compressed
  payload shifts a few bytes between builds of identical source. The
  published DDR2 and DDR3 sizes have already swapped round once between
  two builds an hour apart.
- **`-recovery.bin` is not a thing to flash.** It is built to fit the
  boot ROM's SRAM window for UART upload to a board that will not boot.

Rendered wording is in the diff; no existing text is changed, only
inserted ahead of the `mw.b`/`tftp`/`sf write` block.