### PR TITLE
docs: use ${baseaddr}, not 0x42000000, to flash the bootloader

### DIFF
--- a/en/help-uboot.md
+++ b/en/help-uboot.md
@@ -13,10 +13,18 @@ printenv baseaddr
 
 If it is not there, set it yourself.
 
+The value depends on where DRAM starts on your SoC, which differs by
+generation — copying the wrong one gives `data abort` and a reset.
+
 ```bash
-# Look up address for your SoC at https://openipc.org/supported-hardware/
+# DRAM at 0x80000000: Hi3516CV200, Hi3516CV300, Hi3518EV200, Hi3518EV201
 setenv baseaddr 0x80600000
+
+# DRAM at 0x40000000: Hi3516EV200, Hi3516EV300, Hi3518EV300, GK720x
+setenv baseaddr 0x40600000
 ```
+
+Look up anything not listed at https://openipc.org/supported-hardware/
 
 Assign the hex size of your flash chip to a variable called `flashsize`.
 

--- a/en/install-hisi.md
+++ b/en/install-hisi.md
@@ -92,8 +92,18 @@ Use `${baseaddr}` rather than a literal address. `0x42000000` is only RAM on
 SoCs whose DRAM starts at `0x40000000` (Hi3516EV200/EV300, Hi3518EV300,
 GK720x). On Hi3516CV200 and Hi3518EV200 DRAM starts at `0x80000000`, so that
 address is not memory at all and the command ends in `data abort` and a reset.
-U-Boot already sets `baseaddr` correctly for the board; if `printenv baseaddr`
-comes back empty see [Help: U-Boot](help-uboot.md).
+U-Boot already sets `baseaddr` correctly for the board. If `printenv baseaddr`
+comes back empty, set it from the table below — and do not copy an address out
+of the sections above, which are written for the `0x40000000` family:
+
+| SoC | DRAM base | set `baseaddr` to |
+|---|---|---|
+| Hi3516CV200, Hi3516CV300, Hi3518EV200, Hi3518EV201 | `0x80000000` | `0x82000000` |
+| Hi3516EV200, Hi3516EV300, Hi3518EV300, GK720x | `0x40000000` | `0x42000000` |
+
+If your SoC is not listed, look it up at
+[openipc.org/supported-hardware](https://openipc.org/supported-hardware/)
+rather than guessing.
 
 ```
 printenv baseaddr

--- a/en/install-hisi.md
+++ b/en/install-hisi.md
@@ -88,14 +88,31 @@ The `-recovery.bin` images are a different thing again: they are built to fit
 the boot ROM's SRAM window so they can be uploaded over UART to a board that
 will not boot at all. Do not flash them.
 
+Use `${baseaddr}` rather than a literal address. `0x42000000` is only RAM on
+SoCs whose DRAM starts at `0x40000000` (Hi3516EV200/EV300, Hi3518EV300,
+GK720x). On Hi3516CV200 and Hi3518EV200 DRAM starts at `0x80000000`, so that
+address is not memory at all and the command ends in `data abort` and a reset.
+U-Boot already sets `baseaddr` correctly for the board; if `printenv baseaddr`
+comes back empty see [Help: U-Boot](help-uboot.md).
+
 ```
-mw.b 0x42000000 ff 1000000
-tftp 0x42000000 u-boot-hi3516xxxxx-beta.bin
+printenv baseaddr
+mw.b ${baseaddr} ff 1000000
+tftp ${baseaddr} u-boot-hi3516xxxxx-beta.bin
 sf probe 0
 sf erase 0x0 0x50000
-sf write 0x42000000 0x0 ${filesize}
+sf write ${baseaddr} 0x0 ${filesize}
 reset
 ```
+
+Run those as separate lines, and do not join them into one line with `&&`:
+U-Boot expands `${filesize}` when it parses the line, before `tftp` has run
+and set it, so the write gets no length and does nothing.
+
+Note also that `sf erase 0x0 0x50000` deliberately clears only the bootloader
+and its environment. Erasing the whole chip (`sf erase 0x0 0x1000000`) takes
+the kernel and rootfs with it, and the board will not boot again until all
+three are written back.
 
 [1]: guide-supported-devices.md
 


### PR DESCRIPTION
Found the hard way in OpenIPC/firmware#2299.

The Danger zone block hands out `0x42000000` as the staging address for
`mw.b` / `tftp` / `sf write`. That address is RAM only on SoCs whose DRAM
starts at `0x40000000` — Hi3516EV200/EV300, Hi3518EV300, GK720x. On
Hi3516CV200 and Hi3518EV200 DRAM starts at `0x80000000`, so it is not
memory at all:

```
OpenIPC # mw.b 0x42000000 0xff 0x1000000
data abort
pc : [<808169dc>].   lr : [<00000008>]
...
Resetting CPU ...
```

The page does warn about this — in one line, at the very top. The block
that actually flashes the bootloader is ninety lines below it, tells you
to "replace the filename with the one matching your SoC", and links the
full release list, so it invites every HiSilicon SoC and then gives an
address valid for some of them. The reporter in #2299 had used the
correct `0x82000000` on their first attempt, then spotted the mismatch
with the documentation and "corrected" it to `0x42000000` — which is how
they found the abort.

`baseaddr` is already set correctly by U-Boot per board (`hi-common.h`
ships `baseaddr=0x82000000` for the V2 parts), and `help-uboot.md`
already uses `${baseaddr}` throughout, so this just brings the page in
line with the convention the wiki already has.

Two further notes added from the same report:

- **Do not join the sequence with `&&`.** U-Boot expands `${filesize}`
  when it parses the line, before `tftp` runs and sets it, so the write
  gets no length. The reporter's one-liner reported no obvious failure
  and left the bootloader unwritten.
- **`sf erase 0x0 0x50000` is scoped to bootloader + env on purpose.**
  Erasing the whole chip takes the kernel and rootfs with it. Worth
  stating, because the natural-looking `sf erase 0x0 0x1000000` leaves a
  board that only answers with boot-ROM markers.

Scope: only the Danger zone block. The `0x42000000` in the earlier
sections is left alone — those are under the page's "For XM boards with
Hi35{16Ev200,16Ev300,18Ev300} SoC ONLY!!!" heading, where the address is
correct.