### PR TITLE
majestic: WebRTC is not Ultimate-only, and /webrtc is not where you watch

### DIFF
--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -167,8 +167,13 @@ cloud:
 
 #webrtc:
   # https://www.w3.org/TR/webrtc/#rtciceserver-dictionary with optional
-  # '?transport=udp' or '?transport=tcp'
-  #iceServers: stun:stun.kinesisvideo.eu-north-1.amazonaws.com:443
+  # '?transport=udp' or '?transport=tcp'. Comma-separated; turn: entries need
+  # turnUsername and turnCredential beside them. Unset means
+  # stun:stun.cloudflare.com:3478, which was measured to answer from networks
+  # where the older Google and AWS defaults stayed silent.
+  #iceServers: stun:stun.cloudflare.com:3478
+  #turnUsername:
+  #turnCredential:
 
 # fpv.enabled switches the SigmaStar FPV path on, and also disables
 # userspace 3A. The encoder knobs it used to gate now live per channel,

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -385,10 +385,35 @@ answered with 461.
 
 #### WebRTC in the browser
 
-Ultimate builds serve a page at `http://192.168.1.10/webrtc` with a microphone
-button that sends your browser's microphone to the camera speaker. Browsers only
-grant microphone access in a secure context, so over plain HTTP the button reads
-"needs HTTPS" — put the camera behind TLS or a TLS-terminating reverse proxy.
+Lite and Ultimate builds both carry WebRTC. It used to be Ultimate only, because
+the implementation was a vendored AWS SDK too large for the smaller boards;
+Majestic has its own since, and the SDK is gone.
+
+For **watching**, there is nothing to set up: the WebUI's `Preview` page uses
+WebRTC by default, and so does the live preview beside the image controls in
+`Settings`. Both fall back to the older MSE path on a browser or camera where
+WebRTC cannot be negotiated, so the picture arrives either way. The `WebRTC`
+button on `Preview` shows which one is in use and switches between them.
+
+Watching over WebRTC also lets the camera fit the stream to your connection —
+useful on a thin link, and worth knowing about, because the encoder is shared
+with everything else reading that channel. The preview watches the substream for
+that reason. `videoN.adjustBitrate` turns the adaptation off per channel if the
+rate is committed to something else, such as a recorder.
+
+For **talking back**, use the debug page at `http://192.168.1.10/webrtc`. Its
+`talk` button sends your browser's microphone to the camera speaker. Two things
+have to be true or nothing is heard:
+
+- `audio.outputEnabled` must be on, or the camera answers the offer with audio
+  in one direction only and says so in its log.
+- Browsers only grant microphone access in a secure context, so over plain HTTP
+  the button reads "needs HTTPS" — put the camera behind TLS or a
+  TLS-terminating reverse proxy.
+
+That page is a diagnostic rather than a viewer: it shows the ICE and DTLS state,
+what the camera has sent, and what it has received from you. The WebUI has no
+talkback control yet.
 
 #### SIP
 


### PR DESCRIPTION
Two things had gone stale in the streamer page's WebRTC section.

**It is not Ultimate-only.** That was true when the implementation was a vendored AWS SDK too large for the smaller boards. Majestic has had its own stack for a while, and the SDK has now been removed outright, so Lite carries WebRTC too — which is most of the cameras this page is read on.

**`/webrtc` is not where you watch.** It is a diagnostic: ICE and DTLS state, packet counters, what the camera has received from you. Watching happens in the WebUI — the `Preview` page and the live preview beside the image controls — with no setup at all, and with a fallback to the older MSE path where WebRTC cannot be negotiated. The section now splits along that line instead of pointing everyone at a debug page: **watch in the WebUI, talk back on `/webrtc`.**

Two conditions on talkback that were not written down anywhere and cost time to rediscover:

- `audio.outputEnabled` has to be on, or the camera answers the offer with audio in one direction only — and says exactly that in its log.
- `getUserMedia` is *absent* rather than refused outside a secure context, which is what the button's "needs HTTPS" reading actually means.

Also added, because it surprises people watching a camera that is simultaneously being recorded: a WebRTC viewer lets the camera fit the stream to the viewer's connection, that encoder is shared with everything else reading the channel, and `videoN.adjustBitrate` turns the adaptation off per channel.

## Also in `majestic-config.md`

The `iceServers` example named `stun.kinesisvideo.eu-north-1.amazonaws.com`. The default is `stun.cloudflare.com:3478`, chosen because the Google and AWS servers were measured going unanswered from some networks — exactly the failure an example should not be teaching. The two TURN keys that pair with it are listed alongside.

## Not touched

`dev-buildroot-packages.md` still lists `aws-webrtc (git)` as a buildroot package. Whether that package should go now that nothing consumes it is a call for the firmware maintainers rather than a docs edit, so I have left it and am flagging it here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)