### PR TITLE
majestic: what the Lite, Ultimate and FPV builds each contain

### DIFF
--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -47,9 +47,9 @@ isp:
   #lowDelay: false
   #awbMode: auto                # auto|manual|day|cloudy|incandescent|
                                 # flourescent|twilight|shade|warm|custom
-  #memMode: reduction           # normal | reduction        (HiSilicon)
-  #slowShutter: disabled        # disabled|low|medium|high  (HiSilicon)
-  #dis: false                   # digital stabilisation     (HiSilicon, Ingenic)
+  #memMode: reduction           # normal | reduction        (HiSilicon/Goke)
+  #slowShutter: disabled        # disabled|low|medium|high  (HiSilicon/Goke)
+  #dis: false                   # digital stabilisation     (HiSilicon/Goke, Ingenic)
   #wdr: 0                       #                           (SigmaStar)
   #edgeGain: false              #                           (SigmaStar)
   #iqServer: false              #                           (SigmaStar)
@@ -58,10 +58,10 @@ isp:
                                 # frame buffer, ignored with rotate/mirror/masks
   # Manual exposure and gain. Each is skipped when absent, so leaving it out
   # keeps the automatic behaviour.
-  #exposure: 0                  #                (HiSilicon, SigmaStar, Ingenic)
-  #aGain: 0                     #                (HiSilicon, SigmaStar)
-  #dGain: 0                     #                (HiSilicon)
-  #ispGain: 0                   #                (HiSilicon)
+  #exposure: 0                  #                (HiSilicon/Goke, SigmaStar, Ingenic)
+  #aGain: 0                     #                (HiSilicon/Goke, SigmaStar)
+  #dGain: 0                     #                (HiSilicon/Goke)
+  #ispGain: 0                   #                (HiSilicon/Goke)
 
 image:
   mirror: false
@@ -104,9 +104,9 @@ video0:
   #crop: 0x0x960x540
   # Split a picture into several NAL slices, so one lost packet costs part of a
   # frame instead of all of it.
-  #sliceUnits: 4                # macroblock rows per slice (HiSilicon, SigmaStar)
+  #sliceUnits: 4                # macroblock rows per slice (HiSilicon/Goke, SigmaStar)
   #sliceBytes: 0                # target bytes per slice; wins over sliceUnits
-                                # when both are set          (HiSilicon)
+                                # when both are set          (HiSilicon/Goke)
   # Quantiser bounds. The defaults are per-vendor — read them back from
   # /api/v1/config.json rather than assuming the numbers here.
   #minQp: 28
@@ -120,14 +120,17 @@ video1:
   # video1 takes the same keys as video0
 
 jpeg:
-  enabled: true                 # the /mjpeg stream; /image.jpg works either way
+  enabled: true                 # JPEG as a whole. false frees the snapshot
+                                # channel's frame, but /image.jpg then answers
+                                # 503 and /mjpeg is unavailable -- ONVIF
+                                # snapshots and the WebUI preview with them
   qfactor: 50
   fps: 5                        # MJPEG stream only
   #size: 160x120                # applies to /mjpeg AND /image.jpg
   #osd: true                    # burn the OSD into JPEG output
   rtsp: false                   # also publish MJPEG over RTSP (max 2040 px/axis)
-  #tuned: off                   # HiSilicon only: largest /image.jpg?width=... to
-                                # serve, e.g. 1920x1080. Needs a restart.
+  #tuned: off                   # HiSilicon/Goke only: largest /image.jpg?width=...
+                                # to serve, e.g. 1920x1080. Needs a restart.
 
 osd:
   enabled: false

--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -3,6 +3,24 @@
 
 Majestic example config
 -----------------------
+
+Majestic reads `/etc/majestic.yaml`. A camera only needs the keys it wants to
+change from the defaults, so a working file is usually much shorter than what
+follows — this page is a reference of what exists, not a file to paste whole.
+`/etc/majestic.full` on the camera is a shorter sample of the same thing.
+
+Two ways to check a key against the build you are actually running, which beats
+trusting any wiki page:
+
+```
+curl http://localhost/api/v1/config.json     # every key this binary has, with defaults and ranges
+curl 'http://localhost/api/v1/set?video0.fps=10'   # applies live and saves; 404 if the key is unknown
+```
+
+Sections marked *(build-dependent)* only exist in some builds — see
+[Lite, Ultimate and FPV](majestic-streamer.md#lite-ultimate-and-fpv). Sections
+marked *(platform-dependent)* only exist on the SoCs that can act on them.
+
 ```
 system:
   webPort: 80
@@ -11,40 +29,64 @@ system:
   #httpsCertificateKey: /etc/ssl/private/www.example.com.key
   logLevel: debug
   buffer: 1024
-  plugins: false
+  plugins: false                # load /usr/lib/<vendor>.so, see "Majestic plugins"
+  #telemetry: true              # anonymous install counter (MAC, uptime, chip,
+                                # sensor, flash/SD size) sent as a DNS query
+  #unsafe: false                # true disables ALL authentication
+  #staticDir: /var/www          # where the web interface is served from
 
+# (platform-dependent) Most of this section is per-vendor; the platforms that
+# read each key are noted. A key your build does not have answers 404.
 isp:
-  #sensorConfig: /etc/sensors/imx222_1080p_line.ini
-  antiFlicker: disabled
+  #sensorConfig: /etc/sensors/imx222_1080p_line.ini   # path, or just the sensor name
+  antiFlicker: disabled         # disabled | 50 | 60
   #blkCnt: 4
   #drc: 300
-  #rawMode: slow
+  #rawMode: slow                # none | slow | fast
   #iqProfile: <path/to/file>
   #lowDelay: false
-  #awbMode: auto
-  #memMode: reduction
-  #slowShutter: disabled
-  #dis: false
+  #awbMode: auto                # auto|manual|day|cloudy|incandescent|
+                                # flourescent|twilight|shade|warm|custom
+  #memMode: reduction           # normal | reduction        (HiSilicon)
+  #slowShutter: disabled        # disabled|low|medium|high  (HiSilicon)
+  #dis: false                   # digital stabilisation     (HiSilicon, Ingenic)
+  #wdr: 0                       #                           (SigmaStar)
+  #edgeGain: false              #                           (SigmaStar)
+  #iqServer: false              #                           (SigmaStar)
+  #pad: 0                       #                           (SigmaStar)
+  #yuvCompression: auto         # HiSilicon gen 3/4 only; saves ~1/3 of the main
+                                # frame buffer, ignored with rotate/mirror/masks
+  # Manual exposure and gain. Each is skipped when absent, so leaving it out
+  # keeps the automatic behaviour.
+  #exposure: 0                  #                (HiSilicon, SigmaStar, Ingenic)
+  #aGain: 0                     #                (HiSilicon, SigmaStar)
+  #dGain: 0                     #                (HiSilicon)
+  #ispGain: 0                   #                (HiSilicon)
 
 image:
   mirror: false
   flip: false
-  rotate: 0
+  rotate: 0                     # 0 | 90 | 270
   contrast: 50
   hue: 50
   saturation: 50
   luminance: 50
+  #tuning: false                # automatic image tuning
 
 video0:
   enabled: true
-  codec: h264
+  codec: h264                   # h264 | h265
   #size: 1920x1080
   fps: 20
   bitrate: 4096
-  rcMode: vbr
+  rcMode: vbr                   # cbr | vbr | avbr
+  #profile: main                # base | main | high
   gopSize: 1.0
-  #gopMode: normal
-  #svct: off
+  #gopMode: normal              # normal | dual | smart
+  #adjustBitrate: true          # may a WebRTC viewer on a thin link lower this
+                                # channel's rate; turn off for a channel feeding
+                                # an NVR, a recorder or an outgoing publisher
+  #svct: off                    # off | 2x | 4x — see "Majestic encoder tuning"
   # Encoder reference structure. Every P frame references the keyframe, so
   # one lost frame costs one frame. Wants a SHORT gopSize (~1.0). See
   # "Majestic encoder tuning". Each key here is skipped when absent, so
@@ -60,8 +102,14 @@ video0:
   #roiQp: "-5"
   #bypass: 0
   #crop: 0x0x960x540
-  #sliceUnits: 4
-  #minQp: 12
+  # Split a picture into several NAL slices, so one lost packet costs part of a
+  # frame instead of all of it.
+  #sliceUnits: 4                # macroblock rows per slice (HiSilicon, SigmaStar)
+  #sliceBytes: 0                # target bytes per slice; wins over sliceUnits
+                                # when both are set          (HiSilicon)
+  # Quantiser bounds. The defaults are per-vendor — read them back from
+  # /api/v1/config.json rather than assuming the numbers here.
+  #minQp: 28
   #maxQp: 42
 
 video1:
@@ -69,73 +117,112 @@ video1:
   codec: h264
   size: 704x576
   fps: 15
+  # video1 takes the same keys as video0
 
 jpeg:
-  enabled: true
+  enabled: true                 # the /mjpeg stream; /image.jpg works either way
   qfactor: 50
-  fps: 5
-  #size: 160x120
-  rtsp: false
+  fps: 5                        # MJPEG stream only
+  #size: 160x120                # applies to /mjpeg AND /image.jpg
+  #osd: true                    # burn the OSD into JPEG output
+  rtsp: false                   # also publish MJPEG over RTSP (max 2040 px/axis)
+  #tuned: off                   # HiSilicon only: largest /image.jpg?width=... to
+                                # serve, e.g. 1920x1080. Needs a restart.
 
 osd:
   enabled: false
   font: /usr/share/fonts/truetype/UbuntuMono-Regular.ttf
   template: "%d.%m.%Y %H:%M:%S"
+  #size: "1.0"                  # font scale factor
+  #weight: normal               # normal | thin
+  #outline: true
+  #bgAlpha: 25                  # plate opacity, 0-100
+  # Placement. anchor: proportional (the default) uses posX/posY on their
+  # -16..16 scale; any other anchor uses offsetX/offsetY, measured inward from
+  # that corner or edge. An axis the anchor centres ignores its offset.
+  #anchor: proportional         # proportional | top-left | top | top-right |
+                                # left | center | right | bottom-left | bottom |
+                                # bottom-right
+  #offsetX: "0"
+  #offsetY: "0"
   posX: 16
   posY: 16
   #privacyMasks: 0x0x234x640,2124x0x468x1300
 
+# (build-dependent: absent from FPV builds)
 audio:
   enabled: false
   volume: 30                                              # 0 mutes the input
-  srate: 8000
-  codec: opus
+  #gain: 0                                                # 0-31, analogue gain
+  srate: 8000                                             # 8000|16000|32000|48000
+  codec: opus                   # opus | aac | pcm | alaw | ulaw (| mp3, Ultimate)
   outputEnabled: false
   outputVolume: 30
+  #outputGain: 0
   #speakerPin: 32
   #speakerPinInvert: false
+  #inputChannel: 0
+  #jitterBufferMs: 80           # RTSP back-channel: 0 = passthrough (LAN),
+                                # 80 helps over Wi-Fi/WAN
 
 rtsp:
   enabled: true
   port: 554
+  #alias1: cam/realmonitor      # extra URL path that selects stream 1
+  #alias2: cam/substream        # extra URL path that selects stream 2
+  #backchannel: false           # ONVIF Profile T talkback (needs audio output)
+  #audioCodec: ""               # override audio.codec for RTSP only
 
 nightMode:
-  lightMonitor: true
+  lightMonitor: false
   #irCutPin1: 1
   #irCutPin2: 2
   irCutSingleInvert: false
   #backlightPin: 65
   colorToGray: true
   #overrideDrc: 300
+  #overrideWdr: 0
   #minThreshold: 2000
   #maxThreshold: 5000
   #lightSensorPin: 62
   lightSensorInvert: false
-  #dncDelay: 30
+  #adcReadout: false
+  #monitorDelay: 30             # seconds, 0-60
 
 motionDetect:
   enabled: false
   visualize: false
   debug: false
   #roi: 1854x1304x216x606,1586x1540x482x622
-  #skipIn: 960x540x1920x1080
-  #sensitivity: 3
+  #sensitivity: 3               # 0-8
 
+# path is a DIRECTORY and filename is the base name; the extension is added by
+# Majestic. Both are strftime patterns, expanded when a file is opened. Older
+# configs that put the whole filename in `path` produce a directory of that
+# name — split them.
 records:
   enabled: false
-  path: /mnt/mmcblk0p1/%F/%H.mp4
-  maxUsage: 95
-  #splitRecord: 10
+  path: /mnt/mmcblk0p1/%F       # -> /mnt/mmcblk0p1/2026-08-27/
+  filename: "%H-%M"             # -> 14-30.mp4
+  maxUsage: 95                  # stop when the card is this full, %
+  #split: 20                    # minutes per file, 1-100
+  #substream: false             # record video1 instead of video0
+  #notime: false                # ignore filename, number files 00000.mp4 upward
+  #audioCodec: ""               # mp3 | aac | opus; empty follows audio.codec
+  #key: ""                      # XOR-obfuscate the payload; names files .enc
 
 outgoing:
   enabled: false
   #server: udp://192.168.1.10:5600
   #naluSize: 1200
+  #substream: false                                       # publish video1
+  #thinEnhance: false                                     # send the SVC-T base layer only
   #audioCodec: ""                                         # RTMP audio codec (aac|alaw|ulaw|pcm); empty follows audio.codec
   #audioSource: auto                                      # auto|mic|silence|file|none; silence/file feed a track when there is no microphone
   #audioFile: ""                                          # ADTS .aac looped when audioSource is file
   # Several destinations (majestic.yaml only, not available in the WebUI). Each
   # entry is its own connection: udp/unix as RTP, rtmp/rtmps as RTMP.
+  # rtmp/rtmps needs a Lite or Ultimate build; udp/unix work everywhere.
   #servers:
   #  - udp://IP:port
   #  - unix:/tmp/rtpstream.sock
@@ -148,11 +235,18 @@ watchdog:
 hls:
   enabled: false
 
+mdns:
+  enabled: true                 # answers for openipc.local and <hostname>.local
+
 onvif:
-  enabled: false
+  enabled: true
+  #username: root
+  #password: ""                 # opt-in CLEARTEXT pair, only for clients that
+                                # need WSSE PasswordDigest or HTTP Digest
 
 ipeye:
   enabled: false
+  #model: ""
 
 netip:
   enabled: false
@@ -162,16 +256,43 @@ netip:
   #snapshots: true
   #ignoreSetTime: false
 
+# (build-dependent: Lite and Ultimate)
 cloud:
   enabled: false
+  #host: ""                     # empty keeps the built-in default
+  #port: 0
 
+# (build-dependent: Lite and Ultimate)
+#sip:
+  #enabled: false
+  #server: pbx.example.com
+  #port: 5060
+  #username: doorbell
+  #password: secret
+  #localUri: ""
+  #callTarget: sip:100@pbx.example.com   # several, comma-separated, are allowed
+  #localIp: ""                 # goes into Via/Contact; must be routable back
+  #localPort: 5060
+  #doRegister: true
+  #registerExpires: 3600        # seconds, 60-86400; refreshed at expires-60
+  #buttonPin: 0                 # GPIO wired to the doorbell button
+  #buttonActiveLow: true
+  #rtpPortHint: 5004            # start of the local RTP port scan
+  #ringMode: sequential         # several targets: sequential | parallel
+  #ringSeconds: 10              # 1-300
+  #ringCycles: 3                # 0-100 passes over the target list; 0 = forever
+
+# (build-dependent: Lite and Ultimate)
 #webrtc:
   # https://www.w3.org/TR/webrtc/#rtciceserver-dictionary with optional
-  # '?transport=udp' or '?transport=tcp'. Comma-separated; turn: entries need
-  # turnUsername and turnCredential beside them. Unset means
-  # stun:stun.cloudflare.com:3478, which was measured to answer from networks
-  # where the older Google and AWS defaults stayed silent.
-  #iceServers: stun:stun.cloudflare.com:3478
+  # '?transport=udp' or '?transport=tcp'. A list, separated by commas or
+  # spaces. Unset means stun:stun.cloudflare.com:3478, which was measured to
+  # answer from networks where the older Google and AWS defaults stayed silent.
+  # Set it to 'none' to stop the camera contacting anyone.
+  #iceServers: stun:stun.cloudflare.com:3478, turn:relay.example:3478
+  # Required alongside any turn:/turns: entry. Without both, a browser refuses
+  # to build the connection at all, so an unauthenticated relay is dropped from
+  # the list rather than handed over.
   #turnUsername:
   #turnCredential:
 
@@ -180,5 +301,10 @@ cloud:
 # under video0/video1 with the rest of them.
 #fpv:
   #enabled: false
-
 ```
+
+### See also
+
+- [Majestic streamer](majestic-streamer.md) — endpoints, HTTP API, build flavours
+- [Majestic encoder tuning](majestic-encoder-tuning.md) — `refEnhance`, `refPred`, `svct`, ROI
+- [Majestic plugins](majestic-plugins.md) — what `system.plugins` turns on

--- a/en/majestic-research.md
+++ b/en/majestic-research.md
@@ -1,5 +1,5 @@
 # OpenIPC Wiki
-[Table of Content](../README.md
+[Table of Content](../README.md)
 
 Majestic Usage Research
 -----------------------

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -431,8 +431,14 @@ still snapshots on `/image.jpg` alike; `jpeg.fps` is the MJPEG stream only,
 since a snapshot is taken when it is asked for. Leaving `jpeg.size` unset
 follows the `video0` resolution.
 
-`jpeg.enabled` governs the MJPEG stream and nothing else. Still snapshots work
-whether it is on or off.
+`jpeg.enabled` governs JPEG service as a whole, not just the stream. Turning it
+off reserves no frame for the snapshot channel — which is the single biggest
+memory saving on a small board — but then `/image.jpg` answers **503**, `/mjpeg`
+answers "MJPEG is unavailable", and the JPEG track is dropped from the RTSP
+description. ONVIF snapshot URIs and the web interface preview both fetch
+`/image.jpg`, so they stop working too. See
+[Memory tuning](memory-tuning.md#jpegenabled--snapshots-and-the-mjpeg-stream)
+for what it frees.
 
 Turning on `jpeg.rtsp` publishes the same MJPEG as an RTSP stream. RFC 2435
 caps that at 2040 px per axis, so a larger `jpeg.size` is reduced to 1280x720

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -11,25 +11,125 @@ relation to camera/video surveillance functionality). Majestic is configurable
 via /etc/majestic.yaml file, and has many features/services enabled by default.
 Unneeded options can be switched off for better security and performance. See /etc/majestic.full for configuration options.
 
+### Lite, Ultimate and FPV
+
+Majestic is published in three flavours. They are one streamer with a different
+set of optional parts compiled in, picked for what the camera is *for* rather
+than for what it costs:
+
+- **Lite** — the everyday build, and what almost every camera runs. Everything
+  a surveillance camera is expected to do, including audio, two-way talk,
+  WebRTC in the browser and pushing to YouTube.
+- **Ultimate** — Lite plus the extras that only some owners ask for: MP3 audio
+  and WebP snapshots.
+- **FPV** — a latency-first build for flying. Audio, WebRTC, SIP and RTMP are
+  compiled out, leaving a binary about half the size of Lite that does one
+  thing: put a picture on a radio link and get out of the way.
+
+Which one a camera runs is fixed by the firmware image, not by a setting. Ask
+the binary:
+
+```
+root@openipc-hi3516ev200:~# majestic -v
+Lite HiSilicon (hi3516ev200), 1.0.0, 2026-08-27 09:14
+```
+
+The first word is the flavour. It also appears in the first line of the log at
+every start, and on the built-in player page at `/hls`.
+
+#### In every build
+
+Nothing in the list below depends on the flavour. FPV has all of it too.
+
+H.264 and H.265 encoding on two channels · MJPEG · JPEG, HEIF and YUV
+snapshots · RTSP server, with MJPEG over RTSP · HLS · MP4 recording to a card ·
+ONVIF and WS-Discovery · netip and IPEYE · mDNS · RTP push over `udp://` and
+`unix:` · OSD with privacy masks · motion detection · night mode ·
+the web interface, the HTTP API and HTTPS.
+
+#### What the flavours change
+
+| | FPV | **Lite** | Ultimate |
+|---|:---:|:---:|:---:|
+| Microphone, speaker, `/audio.*` endpoints | — | ✅ | ✅ |
+| Opus, AAC, G.711 A-law / µ-law, raw PCM | — | ✅ | ✅ |
+| [MP3][mp3] audio (`/audio.mp3`, `audio.codec: mp3`) | — | — | ✅ |
+| [WebP][webp] snapshots (`/image.webp`) | — | — | ✅ |
+| Audio track in MP4 recordings | — | ✅ | ✅ |
+| Play a clip on the speaker (`/play_audio`) | — | ✅ | ✅ |
+| RTSP back-channel (ONVIF Profile T talkback) | — | ✅ | ✅ |
+| WebRTC — browser preview, adaptive bitrate, talkback | — | ✅ | ✅ |
+| Cloud signalling (`cloud.enabled`) | — | ✅ | ✅ |
+| SIP client (the doorbell use case) | — | ✅ | ✅ |
+| RTMP and RTMPS push (YouTube, Telegram, VK…) | — | ✅ | ✅ |
+
+The one thing FPV gains in exchange is room. Measured on a Goke GK7205V200,
+same commit, same toolchain, stripped:
+
+| flavour | binary | vs Lite |
+|---|---|---|
+| FPV | 496 KB | −46% |
+| **Lite** | 917 KB | — |
+| Ultimate | 1.24 MB | +38% |
+
+On a camera with 8 MB of flash that difference is the feature.
+
+#### Which cameras get which
+
+Lite is built for every supported SoC. Ultimate is published for GK7205V200,
+GK7205V500, Hi3516CV200, Hi3516CV300 and Hi3516EV200. FPV is published for
+GK7205V200 and Hi3516EV200 — the two chips the flying builds are actually
+flown on.
+
+If a setting or an endpoint from this wiki is missing on your camera, the build
+is the first thing to check: a knob absent from the schema is one this binary
+was not built with, and the API answers `404` for it rather than accepting a
+value nothing would apply. `curl http://localhost/api/v1/config.json` lists
+exactly what your build has.
+
 ### User levels in the system
 
-At the moment, the access has two level in system:
+Majestic authenticates against the system accounts in `/etc/shadow` — the same
+credentials as SSH — and sorts them into two levels:
 
-**root** - the main system user, whose name and password are identical when logging into the system via SSH and WEB, there are no restrictions.
+**root** — full access. The web interface, the API, the terminal and log
+sockets, firmware upgrade, everything.
 
-**viewer** - a user with limited rights who is denied access via SSH and WEB. The user can only receive RTSP requiring authorization. 
-Update by 2024.11.08 - in the near future we will also give him the ability to watch all media resources available on the WEB port, and also 
-control the /night/toggle switch, but the login to the interface itself will still be prohibited. 
-We might also add a specific path to the directory of scripts that it will be allowed to execute
+**any other system account** — media only. Such an account can fetch snapshots
+and the MJPEG stream, watch over WebSocket video, and work the night-mode
+switches, but it cannot log in to the interface or touch the API. Concretely,
+the paths it is allowed are `/image*`, `/mjpeg*`, `/night/*`, `/ws/video` and
+`/cgi-bin/v*`. It also authenticates for RTSP and for ONVIF.
+
+The conventional name for such an account is `viewer`, and creating one takes a
+line:
+
 ```
 adduser viewer -s /bin/false -D -H ; echo viewer:123456 | chpasswd
 ```
 
+A "remember me" session cookie is only ever issued to root, so a media account
+has to present its credentials on each request.
+
+Authentication can be turned off entirely with `system.unsafe: true`. That
+opens every endpoint on the camera to anyone who can reach the port — use it on
+an isolated bench, not on a network.
+
 ### Control signals
 
+| Signal | What it does |
+|---|---|
+| `SIGHUP` | Re-read `/etc/majestic.yaml`, tear the media pipeline down and build it again. This is what `killall -HUP majestic` — and the WebUI, and `cli` — use to apply a change. Repeat signals within 3 seconds are ignored. |
+| `SIGQUIT` | Release the SDK and the video memory with it, but keep the process running and answering. This is how `sysupgrade` frees RAM for a firmware download. A `SIGHUP` afterwards brings the pipeline back. |
+| `SIGINT`, `SIGTERM` | Release the SDK and exit. |
+| `SIGUSR2` | Start or end a SIP call — see [SIP](#sip) below. Only in builds with SIP, and only when `sip.enabled` is set. |
+| `SIGUSR1` | Reserved by Majestic's thread pool. Do not send it. |
+
+On Ingenic, a `SIGHUP` that arrives while a CGI script is running is postponed
+by a second rather than dropped, so a reload during a WebUI action is safe.
+
 ```
--HUP restart Majestic (Except Ingenic T21).
--SIGUSR2 SDK Shutdown (For all platforms).
+killall -HUP majestic
 ```
 
 ### Camera related URLs in firmware
@@ -42,9 +142,33 @@ matches your build rather than whatever was current when a document was written.
 It also fills in the camera's own address, uses the right scheme for your setup
 (http or https, ws or wss), and says whether the endpoints ask for a password.
 
-A JPEG snapshot takes control parameters, for example:
+A JPEG snapshot can be asked for at a size, quality or crop of its own, rather
+than the one `jpeg.*` sets for everybody:
 
-`/image.jpg?width=640&height=360&qfactor=73&color2gray=1`
+`/image.jpg?width=640&height=360&qfactor=73&gray=1&crop=0x0x1280x720`
+
+| parameter | meaning |
+|---|---|
+| `width`, `height` | Size of this snapshot. |
+| `qfactor` | JPEG quality, 1–100. |
+| `gray` | `1` for greyscale. |
+| `crop` | `XxYxWxH` — top-left corner, then size, the same order as `video0.crop`. A malformed value is rejected with `400` rather than quietly ignored. Sets the size too. |
+
+Two conditions apply, because a re-tuned snapshot needs a JPEG encoder
+configured for its own geometry and there is exactly one of those:
+
+- It works on **HiSilicon and Goke only**. Elsewhere the parameters are refused
+  with `501` — set `jpeg.size` and `jpeg.qfactor` in the config instead.
+- `jpeg.tuned` must name the largest size you intend to ask for, e.g.
+  `jpeg.tuned: 1920x1080`, and Majestic must be restarted after setting it. It
+  is `off` by default, because the frame buffers it reserves are paid for
+  whether or not anyone ever asks for a snapshot, and nothing shipped on the
+  camera does — ONVIF, netip and the web interface all take the plain one. A
+  request larger than the cap is refused and says so.
+
+Two clients asking for *different* parameters at the same time is answered with
+`409`; asking for the same ones shares a single capture. A plain `/image.jpg`
+with no parameters is unaffected by any of this and always works.
 
 ### Changing parameters via the HTTP API
 
@@ -76,10 +200,15 @@ EOF
 
 ### Experimental Control Features (not yet described in endpoints)
 
+`/metrics` returns everything below in Prometheus text format, plus process,
+thread-pool, uptime, allocator and HLS counters. The sub-paths return one group
+each:
+
 ```
-/metrics/isp
-/metrics/venc
-/metrics/motion
+/metrics/venc      encoder counters
+/metrics/isp       ISP parameters
+/metrics/night     day/night state and light level
+/metrics/motion    motion detection state
 ```
 ```
 /night/ircut
@@ -140,7 +269,14 @@ curl http://localhost/api/v1/config --data-binary @- <<'EOF'
 EOF
 ```
 
-Reboot the camera and restart `majestic` in the foreground:
+Motion detection is set up when the media pipeline is built, so unlike most
+settings this one needs a reload to take effect:
+
+```
+killall -HUP majestic
+```
+
+To watch it work, run Majestic in the foreground instead:
 
 ```
 killall majestic; sleep 3; majestic
@@ -172,8 +308,10 @@ curl http://localhost/api/v1/config --data-binary @- <<'EOF'
   }
 }
 EOF
-reboot
 ```
+
+The API applies this live and saves it; no reboot is needed. RTMP is in Lite
+and Ultimate builds, not FPV.
 
 Examples of other addresses for different services:
 - YouTube
@@ -252,31 +390,65 @@ If both `server` and `servers` are present, they are combined.
 
 ### ONVIF
 
-For basic ONVIF to work correctly, you need to enable it and add a user to the system as shown in the example:
+ONVIF is on by default (`onvif.enabled: true`). It authenticates against the
+system accounts, so the account an NVR logs in with has to exist:
 
 ```
-curl 'http://localhost/api/v1/set?onvif.enabled=true'
 adduser viewer -s /bin/false -D -H
 echo viewer:123456 | chpasswd
 ```
 
+Some clients cannot work that way. WSSE `PasswordDigest` and HTTP Digest both
+require the camera to *know* the password rather than just verify it, and a
+hash in `/etc/shadow` cannot be used for that — so a client that speaks only
+those, such as tinyCam Monitor or ONVIF Device Manager 2.2.x, is refused. For
+those, set an ONVIF-only credential pair:
+
+```
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "onvif": {
+    "username": "viewer",
+    "password": "123456"
+  }
+}
+EOF
+```
+
+It is opt-in and empty by default, and it is stored **in cleartext** in
+`/etc/majestic.yaml` — that is the trade being made, so only set it if a client
+needs it. When set, it is checked first and the `/etc/shadow` lookup is the
+fallback.
+
+Majestic also answers mDNS (`mdns.enabled`, on by default) alongside ONVIF's own
+WS-Discovery: `openipc.local` always, and `<hostname>.local` as well, so a
+renamed camera stays reachable under both.
+
 ### JPEG and MJPEG
 
-For the purpose of unification and standardization for all platforms, as well as to increase the stability of the streamer, the image size will always be equal to the size on the Video0 channel and a separate setting is not provided.
+`jpeg.size` and `jpeg.qfactor` apply to the MJPEG stream on `/mjpeg` **and** to
+still snapshots on `/image.jpg` alike; `jpeg.fps` is the MJPEG stream only,
+since a snapshot is taken when it is asked for. Leaving `jpeg.size` unset
+follows the `video0` resolution.
+
+`jpeg.enabled` governs the MJPEG stream and nothing else. Still snapshots work
+whether it is on or off.
+
+Turning on `jpeg.rtsp` publishes the same MJPEG as an RTSP stream. RFC 2435
+caps that at 2040 px per axis, so a larger `jpeg.size` is reduced to 1280x720
+with a warning in the log.
 
 ###  ROI
 
-Detection zones of two types:
+Motion detection can be restricted to one or more regions of interest:
 
 `motionDetect.roi: 1854x1304x216x606,1586x1540x482x622`
 
-`motionDetect.skipIn: 960x540x1920x1080`
+Only movement inside a listed region raises an event. With no `roi` set the
+whole frame is watched.
 
-**roi** - region of interest, when we specify one or more regions whose movements we are interested in.
-
-**skipIn** - on the contrary, if we are interested in movements on the whole screen, except for some areas (for example, there is a tree in the frame, which is swaying in the wind).
-
-Coordinate format is the same as in osd.privacyMasks: x,y of the top left point, length and width in pixels.
+Coordinate format is the same as in `osd.privacyMasks` and `video0.crop`: x,y
+of the top left point, then width and height in pixels.
 
 ### How to convert YUV image to a more common image format
 
@@ -296,6 +468,11 @@ ffplay -ar 48000 -ac 1 -f alaw http://192.168.1.10/audio.alaw
 ffplay -ar 48000 -ac 1 -f mulaw http://192.168.1.10/audio.ulaw
 ffplay -ar 8000 -ac 1 -f alaw http://192.168.1.10/audio.g711a
 ```
+
+There are also `/audio.opus` and `/audio.m4a` (AAC), which ffplay reads without
+being told the rate, and `/audio.mp3` in Ultimate builds. `/audio.html` is a
+small player page for them. All of them answer `501` while `audio.enabled` is
+off.
 
 ### Enabling the speaker
 
@@ -385,9 +562,10 @@ answered with 461.
 
 #### WebRTC in the browser
 
-Lite and Ultimate builds both carry WebRTC. It used to be Ultimate only, because
-the implementation was a vendored AWS SDK too large for the smaller boards;
-Majestic has its own since, and the SDK is gone.
+Lite and Ultimate builds both carry WebRTC ([see above](#what-the-flavours-change)).
+It used to be Ultimate only, because the implementation was a vendored AWS SDK
+too large for the smaller boards; Majestic has its own since, and the SDK is
+gone.
 
 For **watching**, there is nothing to set up: the WebUI's `Preview` page uses
 WebRTC by default, and so does the live preview beside the image controls in
@@ -419,7 +597,16 @@ talkback control yet.
 
 Lite and Ultimate builds include a SIP client. Point the `sip.*` settings at a
 PBX and the camera can place a call carrying H.264 video and G.711 audio in both
-directions, optionally triggered by a GPIO button — the usual doorbell setup.
+directions, optionally triggered by a GPIO button (`sip.buttonPin`) — the usual
+doorbell setup.
+
+A call can also be started and ended from a script, without a button:
+
+```
+killall -USR2 majestic
+```
+
+The first signal originates the call, the next one hangs it up.
 
 #### Caveat
 
@@ -442,6 +629,7 @@ push-to-talk is unaffected.
 [raw]: https://en.wikipedia.org/wiki/Raw_image_format
 [rtsp]: https://en.wikipedia.org/wiki/RTSP
 [ulaw]: https://en.wikipedia.org/wiki/%CE%9C-law_algorithm
+[webp]: https://en.wikipedia.org/wiki/WebP
 [yuv]: https://en.wikipedia.org/wiki/YUV
 [ffplay]: https://ffmpeg.org/ffplay.html
 [ffmpeg]: https://ffmpeg.org/


### PR DESCRIPTION
People keep asking how the three Majestic builds differ, so the answer now sits on the page they already read.

### What's new

A **Lite / Ultimate / FPV** section in `majestic-streamer.md`: what every build shares, a table of what the flavours actually change, how to ask a camera which one it is running (`majestic -v`), and which SoCs each flavour is published for.

The sizes in it are measured, not estimated — GK7205V200 built three times off the same commit with the same toolchain, stripped:

| flavour | binary |
|---|---|
| FPV | 496 KB |
| Lite | 917 KB |
| Ultimate | 1.24 MB |

### What was wrong

Checking every claim on these pages against the streamer turned up a fair amount of drift:

- `motionDetect.skipIn`, `nightMode.dncDelay` and `records.splitRecord` no longer exist. The real keys are `records.split` and `nightMode.monitorDelay`.
- `records.path` is a **directory** and `records.filename` the base name; the extension is appended. The documented `path: /mnt/.../%H.mp4` creates a directory of that name.
- The signal table was wrong. `SIGUSR2` places and ends a SIP call — it is not "SDK shutdown". `SIGQUIT` is the one that releases the SDK while the process keeps serving, which is what `sysupgrade` uses. The Ingenic caveat is a one-second deferral while a CGI runs, not a T21 special case.
- The snapshot parameter is `gray`, not `color2gray` — and a parameterised snapshot additionally needs HiSilicon and `jpeg.tuned`, so the documented URL fails on most cameras.
- `jpeg.size` exists and applies to both `/mjpeg` and `/image.jpg`, where the page said no such setting was provided.
- A non-root system account already reaches the media endpoints over HTTP; the page still described that as a future intention. `onvif.enabled` defaults to `true`, and the `onvif.username`/`password` pair that unlocks digest auth for older clients (ODM 2.2.x, tinyCam) was undocumented.

`majestic-config.md` also gains the sections that were missing outright — `sip`, `mdns`, `cloud`, the RTSP aliases and back-channel, the OSD anchor and offsets — and marks per-vendor keys as such, since a key the build lacks answers `404` rather than being accepted and ignored.

Plus one unclosed markdown link in `majestic-research.md`.

`majestic-encoder-tuning.md` and `majestic-plugins.md` were checked against the source too and needed nothing.