### PR TITLE
majestic: the overlay is per stream, and privacy masks are not part of it

### DIFF
--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -89,9 +89,9 @@ video0:
   #osd: true                    # draw the overlay on THIS stream. The overlay is
                                 # rendered per stream and sized for this stream's
                                 # own frame, so turning it off here leaves the
-                                # other streams stamped. Does not affect privacy
-                                # masks, except on Ingenic — see "On-screen
-                                # display and privacy masks"
+                                # other streams stamped. Privacy masks are not
+                                # affected — see "On-screen display and privacy
+                                # masks"
   #svct: off                    # off | 2x | 4x — see "Majestic encoder tuning"
   # Encoder reference structure. Every P frame references the keyframe, so
   # one lost frame costs one frame. Wants a SHORT gopSize (~1.0). See
@@ -149,9 +149,8 @@ jpeg:
 
 osd:
   enabled: false                # the TEXT overlay. Privacy masks below are not
-                                # part of it and do not need it — except on
-                                # Ingenic, where they still do. Which streams get
-                                # the text is then video0.osd / video1.osd /
+                                # part of it and do not need it. Which streams
+                                # get the text is then video0.osd / video1.osd /
                                 # jpeg.osd, each on by default
   font: /usr/share/fonts/truetype/UbuntuMono-Regular.ttf
   template: "%d.%m.%Y %H:%M:%S"

--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -86,6 +86,12 @@ video0:
   #adjustBitrate: true          # may a WebRTC viewer on a thin link lower this
                                 # channel's rate; turn off for a channel feeding
                                 # an NVR, a recorder or an outgoing publisher
+  #osd: true                    # draw the overlay on THIS stream. The overlay is
+                                # rendered per stream and sized for this stream's
+                                # own frame, so turning it off here leaves the
+                                # other streams stamped. Does not affect privacy
+                                # masks, except on Ingenic — see "On-screen
+                                # display and privacy masks"
   #svct: off                    # off | 2x | 4x — see "Majestic encoder tuning"
   # Encoder reference structure. Every P frame references the keyframe, so
   # one lost frame costs one frame. Wants a SHORT gopSize (~1.0). See
@@ -117,6 +123,9 @@ video1:
   codec: h264
   size: 704x576
   fps: 15
+  #osd: true                    # as video0.osd, and on by default here too: a
+                                # sub stream carries the overlay unless this is
+                                # turned off
   # video1 takes the same keys as video0
 
 jpeg:
@@ -127,7 +136,9 @@ jpeg:
   qfactor: 50
   fps: 5                        # MJPEG stream only
   #size: 160x120                # applies to /mjpeg AND /image.jpg
-  #osd: true                    # burn the OSD into JPEG output
+  #osd: true                    # burn the OSD into JPEG output, sized for the
+                                # snapshot's own frame rather than the main
+                                # stream's
   rtsp: false                   # also publish MJPEG over RTSP (max 2040 px/axis)
   #tuned: off                   # HiSilicon/Goke only: largest /image.jpg?width=...
                                 # to serve, e.g. 1920x1080. Needs a restart.
@@ -137,7 +148,11 @@ jpeg:
                                 # image, ~5% smaller, and costs CPU per snapshot
 
 osd:
-  enabled: false
+  enabled: false                # the TEXT overlay. Privacy masks below are not
+                                # part of it and do not need it — except on
+                                # Ingenic, where they still do. Which streams get
+                                # the text is then video0.osd / video1.osd /
+                                # jpeg.osd, each on by default
   font: /usr/share/fonts/truetype/UbuntuMono-Regular.ttf
   template: "%d.%m.%Y %H:%M:%S"
   #size: "1.0"                  # font scale factor
@@ -154,6 +169,11 @@ osd:
   #offsetY: "0"
   posX: 16
   posY: 16
+  # Rectangles of the picture to black out, written against the MAIN stream's
+  # frame and scaled into each of the others. They cover every stream that is
+  # running -- both video channels and the snapshot -- and a rectangle covering
+  # nothing is ignored. See "On-screen display and privacy masks" for what each
+  # SoC family can and cannot do.
   #privacyMasks: 0x0x234x640,2124x0x468x1300
 
 # (build-dependent: absent from FPV builds)
@@ -198,7 +218,10 @@ nightMode:
 
 motionDetect:
   enabled: false
-  visualize: false
+  visualize: false              # draw a box around what moved. On SigmaStar this
+                                # and osd.privacyMasks cannot both be drawn; if
+                                # masks are set the masks are kept and the boxes
+                                # are not drawn
   debug: false
   #roi: 1854x1304x216x606,1586x1540x482x622
   #sensitivity: 3               # 0-8
@@ -313,5 +336,7 @@ cloud:
 ### See also
 
 - [Majestic streamer](majestic-streamer.md) — endpoints, HTTP API, build flavours
+- [On-screen display and privacy masks](majestic-streamer.md#on-screen-display-and-privacy-masks)
+  — which streams get the overlay, and what masks do on each SoC family
 - [Majestic encoder tuning](majestic-encoder-tuning.md) — `refEnhance`, `refPred`, `svct`, ROI
 - [Majestic plugins](majestic-plugins.md) — what `system.plugins` turns on

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -333,26 +333,21 @@ Each rectangle is `left x top x width x height` in main-stream pixels — the sa
 format as `video0.crop`. A rectangle with no width or height covers nothing and
 is ignored.
 
+Masks do not need `osd.enabled`, and they do not follow `video0.osd`,
+`video1.osd` or `jpeg.osd`. A camera that has never shown a timestamp can still
+hide part of the scene, and turning a clock off never uncovers anything.
+
 #### What each SoC family can do
 
-Privacy masks are implemented on HiSilicon/Goke, SigmaStar and Ingenic. Other
-SoCs draw the text overlay but have no masks, so `osd.privacyMasks` does nothing
-there.
+Privacy masks are implemented on HiSilicon/Goke, SigmaStar and Ingenic, and
+behave the same way on all three. Other SoCs draw the text overlay but have no
+masks, so `osd.privacyMasks` does nothing there.
 
-| | Masks without `osd.enabled` | Masks when a stream's text is off | Masks on every stream |
-| --- | --- | --- | --- |
-| HiSilicon/Goke | yes | yes | yes |
-| SigmaStar | yes | yes | yes |
-| Ingenic | **no** | **no** | only where the text is drawn |
-
-On Ingenic the masks are drawn by the same stage that draws the text, so they
-need `osd.enabled: true`, and a stream with `video1.osd: false` gets neither. If
-you rely on masks there, leave the text switches on.
-
-On SigmaStar, `motionDetect.visualize` and privacy masks cannot both be drawn —
-they need the same hardware, and each wants it configured its own way. Masks win:
-with both set, the picture stays masked and the motion boxes are not drawn. With
-no masks configured, `visualize` behaves as before.
+One exception is worth knowing. On SigmaStar, `motionDetect.visualize` and
+privacy masks cannot both be drawn — they need the same hardware, and each wants
+it configured its own way. Masks win: with both set, the picture stays masked and
+the motion boxes are not drawn. With no masks configured, `visualize` behaves as
+before.
 
 ### Motion detection
 

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -292,6 +292,68 @@ curl http://localhost/api/v1/config --data-binary @- <<'EOF'
 EOF
 ```
 
+### On-screen display and privacy masks
+
+Two different things share the `osd` section, and they answer to different
+switches.
+
+The **text overlay** is the timestamp, or whatever `osd.template` renders. It is
+drawn on each stream separately and sized for that stream's own frame, so the
+clock takes up about as much of a 704x576 sub stream as it does of a 2592x1520
+main one. Turn it on with `osd.enabled`, then choose which streams carry it:
+
+| Key | Default | Applies to |
+| --- | --- | --- |
+| `video0.osd` | `true` | the main stream |
+| `video1.osd` | `true` | the sub stream |
+| `jpeg.osd` | `true` | `/image.jpg` and `/mjpeg` |
+
+All three are on by default, so `osd.enabled: true` alone stamps every stream.
+Turning one off leaves the others stamped.
+
+A **privacy mask** is not part of that. It is a rectangle of the picture blacked
+out, and it covers every stream that is running — both video channels and the
+snapshot — because a stream showing the picture has to hide the same part of it.
+Turning the text off on a stream does not uncover the mask.
+
+Masks are written against the main stream's frame and scaled into each of the
+others, so one rectangle describes the same part of the scene everywhere:
+
+```
+curl http://localhost/api/v1/config --data-binary @- <<'EOF'
+{
+  "osd": {
+    "privacyMasks": "200x200x1200x900"
+  }
+}
+EOF
+```
+
+Each rectangle is `left x top x width x height` in main-stream pixels — the same
+format as `video0.crop`. A rectangle with no width or height covers nothing and
+is ignored.
+
+#### What each SoC family can do
+
+Privacy masks are implemented on HiSilicon/Goke, SigmaStar and Ingenic. Other
+SoCs draw the text overlay but have no masks, so `osd.privacyMasks` does nothing
+there.
+
+| | Masks without `osd.enabled` | Masks when a stream's text is off | Masks on every stream |
+| --- | --- | --- | --- |
+| HiSilicon/Goke | yes | yes | yes |
+| SigmaStar | yes | yes | yes |
+| Ingenic | **no** | **no** | only where the text is drawn |
+
+On Ingenic the masks are drawn by the same stage that draws the text, so they
+need `osd.enabled: true`, and a stream with `video1.osd: false` gets neither. If
+you rely on masks there, leave the text switches on.
+
+On SigmaStar, `motionDetect.visualize` and privacy masks cannot both be drawn —
+they need the same hardware, and each wants it configured its own way. Masks win:
+with both set, the picture stays masked and the motion boxes are not drawn. With
+no masks configured, `visualize` behaves as before.
+
 ### Motion detection
 
 Motion detect is supported for HiSilicon/Goke, Ingenic and Sigmastar.


### PR DESCRIPTION
Two things share the `osd` section and answer to different switches, which these pages never said — so `privacyMasks` sat under a heading whose `enabled` key looked like it governed them.

## What changed on the cameras

- The **text overlay** is drawn per stream and sized for each stream's own frame, instead of once from the main stream and pasted onto the rest. A clock that took a quarter of a 2560-wide picture no longer takes half of a 704-wide one.
- Which streams carry it is `video0.osd`, `video1.osd` and `jpeg.osd`. **All three default to `true`**, so a sub stream shows a timestamp it did not have before — the switch to turn that off ships with it. Worth a line in release notes.
- `jpeg.osd` takes effect again on HiSilicon/Goke, where it had stopped doing anything.
- **Privacy masks** cover every running stream — both video channels and the snapshot — and no longer depend on `osd.enabled` or follow the per-stream switches on any SoC. They are written against the main stream's frame and scaled into the others, so one rectangle describes the same part of the scene everywhere.

## No SoC table

An earlier revision of this PR had one, because Ingenic was then the odd one out: its masks were drawn by the same stage as the text, so they needed `osd.enabled` and vanished with `video1.osd: false`. That is fixed, and all three families with privacy masks now behave identically — three identical rows earn nothing, and a table invites the reader to hunt for a difference that is no longer there.

What is left is the part that still varies: which families have masks at all (HiSilicon/Goke, SigmaStar, Ingenic — others draw text and ignore the key), and the SigmaStar either/or where `motionDetect.visualize` and privacy masks want the same hardware configured different ways. The masks keep it.

## Notes

- English only — there are no `ru/` Majestic pages.
- `cspell` clean on both files.
- The new section is linked from the config page's *See also*.