### PR TITLE
docs: how an IR-cut filter is actually driven, and four corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ OpenIPC Wiki
 - [Board specific GPIO settings list](en/gpio-settings.md)
 - [ACMEv2](en/acme-v2.md)
 - [WiFi XM530](en/wifi-xm530.md)
+- [How an IR-cut filter is driven](en/ircut-filter.md)
 - [Automatic night mode without light sensor](en/auto-night-mode-without-light-sensor.md)
 - [ZeroTier setup](en/zerotier.md)
 - [Motor control](en/motors.md)

--- a/en/auto-night-mode-without-light-sensor.md
+++ b/en/auto-night-mode-without-light-sensor.md
@@ -1,7 +1,16 @@
 # OpenIPC Wiki
 [Table of Content](../README.md)
 
-**Attention, this instruction is outdated since summer 2024 and now [control](https://github.com/OpenIPC/wiki/blob/master/en/majestic-streamer.md#auto-daynight-detection) of Majestic modes is possible from the Web interface !**
+**Attention, this instruction is outdated since summer 2024.** Majestic switches
+day/night by itself from the sensor's analog gain — see
+[auto day/night detection](majestic-streamer.md#auto-daynight-detection) for the
+two settings that replace these scripts, and set them from **Settings → Day /
+Night** in the web interface.
+
+**Step 1 below is also done for you now.** The web interface detects a filter
+that is open in daylight, and its **Test the filter** button moves the filter and
+compares the picture to tell "wired backwards" from "not wired". See
+[How an IR-cut filter is driven](ircut-filter.md).
 
 
 Auto nightmode on devices without a light sensor
@@ -11,8 +20,15 @@ Not all devices have an onboard light sensor to determine whether night mode sho
 For these devices, we can use the image sensor's analog gain value to switch. In low-light conditions, this value will be high, indicating the image sensor is applying gain to boost brightness. In well-lit conditions, this value will be low.
 
 #### Step 1: determine if IR cut filter is set up correctly
-This article assumes you have found and entered the correct GPIO pins for your IR cut filter and you are able to toggle the filter using the `IR-cut filter` button in the preview. During daylight conditions, in the preview, the image should not be pink.
-If it is pink, most likely your pins are in the wrong order and they need to be swapped in `Majestic > Night Mode`.
+This article assumes you have found and entered the correct GPIO pins for your IR
+cut filter and can toggle the filter — the **IR-cut** switch is on
+**Settings → Live adjustments** (it moved off the Live page, which is read-only).
+During daylight the image should not be pink. If it is, most likely your pins are
+in the wrong order and want swapping on the pin map in **Settings → Day / Night**.
+
+Rather than judging this by eye, press **Test the filter** on that page: it moves
+the filter, compares the picture in both positions, and says which of "wired
+correctly", "wired backwards" and "stuck" it found.
 
 #### Step 2: install night mode scripts
 We need 2 scripts: the actual night mode script and the startup script that enables the night mode script at boot.

--- a/en/gpio-settings.md
+++ b/en/gpio-settings.md
@@ -238,6 +238,19 @@ Tested on GK7205V300 for /dev/ttyАМА1:
 > IRCTL is a backlightPin<br>
 > IRSTATUS is a lightSensorPin
 
+**The two IRCUT pads are one H-bridge, and their order matters.** They are not
+independent switches: which of them is driven high while the other is held low is
+what decides whether the filter closes or opens, so a swapped pair gives you a
+correctly-moving filter that is pink in daylight. **Settings → Day / Night** has
+a **Test the filter** button that moves it and reports "wired correctly", "wired
+backwards" or "stuck" — quicker than reasoning about it, and it does not require
+waiting for nightfall. See [How an IR-cut filter is driven](ircut-filter.md).
+
+**This table is read by software as well as by people.** The web interface's pin
+scan tries the pairs recorded here before anything else, so a board listed below
+is normally found within seconds while an unlisted one falls back to a much
+longer sweep. Adding a board here helps the next person twice over.
+
 [^1]: 00014914 firmware
 [^2]: 00014911 firmware
 [^3]: 000699Q3 firmware

--- a/en/ircut-filter.md
+++ b/en/ircut-filter.md
@@ -1,0 +1,138 @@
+# OpenIPC Wiki
+[Table of Content](../README.md)
+
+## How an IR-cut filter is driven
+
+The IR-cut filter is a small glass shutter in front of the sensor. Daylight needs
+it **closed**, or infrared reaches the sensor through the Bayer dyes and every
+colour goes pink. Night needs it **open**, or the infrared illuminator is wasted
+on a filter that blocks the very light it emits.
+
+Getting this wrong is unusually quiet. The camera streams, records, answers ONVIF
+and reports healthy counters the whole time; the only symptom is the picture, and
+the picture only tells you at the wrong time of day. The commonest fault is not a
+wrong value but a **missing** one — with no `nightMode.irCutPin1` majestic never
+drives the filter at all, so it stays wherever it powered up.
+
+This article is the hardware half. For the settings, see
+[Majestic example config](majestic-config.md); for the pin numbers other people
+have found, [Board specific GPIO settings list](gpio-settings.md).
+
+---
+
+### It takes two pads, not one
+
+The filter is moved by an H-bridge across **two** GPIO pads. No single-pad
+operation actuates it. Measured on a XiongMai 85H50AI (Hi3516EV300, pads 11 and
+10), every state one pad can reach:
+
+| what you do | what the filter does |
+|---|---|
+| float either pad | **opens** — the brake is released |
+| drive both pads low | **holds** its position, drawing no current |
+| pad A high, pad B low | moves one way |
+| pad B high, pad A low | moves the other way |
+
+So `irCutPin1` and `irCutPin2` are not two independent switches, and pulsing one
+of them on its own proves nothing. They are the two ends of one bridge, and the
+direction of travel is decided by *which* of them is driven high while the other
+is held low.
+
+### Two kinds of filter, and telling them apart
+
+**Latching (bistable).** A pulse moves it and it stays where it was put. The pads
+can be released afterwards and the filter holds.
+
+**Brake-held.** Driving both pads low is a brake that holds the position; letting
+the pads float releases the brake and the filter springs open. The 85H50AI is
+this kind. On such a board majestic must keep both pads exported and driven for
+the day position to survive — so if you see it holding GPIOs it is not leaking
+them, it is holding the filter shut.
+
+You can tell which you have in one step: close the filter, then release both pads
+to inputs and look at the picture. If it goes pink, the filter is brake-held. If
+it stays correct, it latches. The WebUI does exactly this as part of its pin scan
+and reports the answer.
+
+### The metrics do not read the way you expect
+
+```
+night_enabled 0     # majestic is in DAY mode
+ircut_enabled 0     # the filter is CLOSED  (correct colour in daylight)
+ircut_enabled 1     # the filter is OPEN    (pink in daylight)
+```
+
+**`ircut_enabled` is 1 when the filter is out of the light path**, not when the
+filter is "on". It tracks the night position. Verified by toggling
+`/night/ircut` in daylight and watching the picture: `0` gives normal colour, `1`
+gives magenta.
+
+`night_enabled` and `ircut_enabled` should agree — `0/0` is day with the filter
+closed, `1/1` is night with it open. A camera sitting at `night_enabled 0` and
+`ircut_enabled 1` in daylight is showing you the pink picture and saying so.
+
+Note that a majestic build that does not publish these gauges omits them
+entirely. An absent gauge is not a zero: "no day/night state reported" and "day
+with the filter closed" are different answers, and anything reading `/metrics`
+should distinguish them.
+
+---
+
+### Setting it up
+
+Since the Day / Night rebuild, the WebUI does most of this for you. On
+**Settings → Day / Night** you get a map of the camera's GPIO pads (built from
+what the kernel reports, so it is the right size on every SoC) with four things
+to connect: the filter's closing coil, its opening coil, the infrared lamp and
+the daylight sensor. Click a pad, pick what it is.
+
+Two buttons matter:
+
+- **Find them for me** drives candidate pairs and watches the picture for the
+  filter to move. It tries the pairs this wiki's
+  [GPIO table](gpio-settings.md) has recorded first, so a board already listed
+  there is usually found in seconds. **It needs daylight** — the test reads the
+  picture, and at night nothing looks like it moved.
+- **Test the filter** moves it and compares the picture in both positions. This
+  is the only way to tell "wired backwards" from "not wired" without waiting for
+  nightfall, and it will tell you which you have.
+
+If the test says **wired backwards**, swap the two coils on the map. On a board
+with a single coil pad, turn on `Single IRcut is inverted` instead.
+
+The dashboard also raises a banner on its own when the configuration cannot work
+— no pin set, a light monitor with nothing to watch, thresholds with no
+hysteresis, or day and night disagreeing for long enough to be real.
+
+> **The scan drives pads whose job is unknown**, and one of them may reset the
+> network, cut power to the sensor or stop the camera answering. That risk cannot
+> be removed, only made survivable: the pads being driven are written to flash
+> before any register is touched, so a camera that has to be restarted comes back
+> knowing which pair did it and excludes them. Pads a kernel driver holds are
+> refused outright. Prefer entering known pins from the table when you have them.
+
+### Doing it by hand
+
+The pin numbers other people have found are in
+[Board specific GPIO settings list](gpio-settings.md); `IRCUT1` is `irCutPin1`
+and `IRCUT2` is `irCutPin2`. If your board is not listed, adding it there helps
+the next person **and** the scanner, which uses that table as its search order.
+
+If you are still on the vendor firmware, run `ipctool` **before** you flash: the
+stock application leaves the IR-cut pads configured as driven outputs, which is
+how `ipctool gpio scan` recognises them. After conversion that evidence is gone —
+nothing has claimed those pads and the registers know nothing about the wiring.
+
+### If the picture is pink in daylight
+
+In order of likelihood:
+
+1. **No pins set.** The filter is wherever it powered up and nothing moves it.
+   Check `nightMode.irCutPin1`.
+2. **Pins reversed.** The filter opens when it should close. Run the filter test;
+   it names this outcome.
+3. **Wrong pins.** They drive something else, or nothing. The test reports the
+   filter as stuck, because it does not move in either position.
+4. **Night mode is on.** Check `night_enabled`. An open filter at night is the
+   filter working correctly, and in a dark room a camera in night mode looks
+   exactly like a camera with a broken filter.

--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -199,20 +199,19 @@ rtsp:
   #backchannel: false           # ONVIF Profile T talkback (needs audio output)
   #audioCodec: ""               # override audio.codec for RTSP only
 
-nightMode:
+nightMode:                      # see en/ircut-filter.md for how the filter is
+                                # actually driven, and what the metrics mean
   lightMonitor: false
-  #irCutPin1: 1
-  #irCutPin2: 2
-  irCutSingleInvert: false
+  #irCutPin1: 1                 # the two coils of one H-bridge, not two
+  #irCutPin2: 2                 # switches — order decides which way it moves
+  irCutSingleInvert: false      # for a board with a single coil pad
   #backlightPin: 65
   colorToGray: true
   #overrideDrc: 300
-  #overrideWdr: 0
-  #minThreshold: 2000
-  #maxThreshold: 5000
+  #minThreshold: 2000           # compared against isp_again, whose units are
+  #maxThreshold: 5000           # per-SoC: read your own before choosing
   #lightSensorPin: 62
   lightSensorInvert: false
-  #adcReadout: false
   #monitorDelay: 30             # seconds, 0-60
 
 motionDetect:

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -271,6 +271,10 @@ root@openipc-ssc377d:~# wget -q -O - http://localhost/night/toggle
 
 ### Auto day/night detection
 
+For how the filter itself is wired and driven — and why a swapped pair gives you
+a pink daylight picture — see
+[How an IR-cut filter is driven](ircut-filter.md).
+
 If these variables are used, it is possible to replace the used sandbox scripts.
 Works only for simple day/night schemes with minimal configuration and in the absence of mentions of lightSensorPin in the majestic.yaml configuration file.
 If the light sensor gpio is set, it will use the default mode.
@@ -278,8 +282,16 @@ If the light sensor gpio is set, it will use the default mode.
 The settings work like this:
 ```day < [minThreshold] | hysteresis | [maxThreshold] < night```
 
-If the sensor gain is 1024 on a bright day the minThreshold could be set to 2000,
-if the sensor gain is 32000 on a dark night the maxThreshold could be set to 10000.
+**These numbers are per-SoC — read your own camera's `isp_again` before picking
+them.** The gauge is in the SDK's own units and they are not comparable between
+vendors: the same idle, no-extra-gain state reads about **1024 on HiSilicon, 126
+on Ingenic and 20855 on SigmaStar**. A threshold copied from a HiSilicon example
+onto an Ingenic camera simply never trips.
+
+On a HiSilicon camera reading 1024 on a bright day, minThreshold could be set to
+2000; if it reads 32000 on a dark night, maxThreshold could be set to 10000. Watch
+`isp_again` at `/metrics` in your own conditions and pick a band inside it, with
+minThreshold below maxThreshold so there is hysteresis to sit in.
 
 ```
 curl http://localhost/api/v1/config --data-binary @- <<'EOF'


### PR DESCRIPTION
The wiki explained how to *configure* an IR-cut filter but never how one **works**, which left the questions people actually hit unanswerable: why pulsing a pin does nothing, why the filter opens on its own, why majestic holds GPIOs and never releases them, and why `ircut_enabled` reads 1 when the filter is *out* of the light path.

### New: `en/ircut-filter.md`

The hardware half. Measured on a XiongMai 85H50AI (Hi3516EV300, pads 11/10) rather than reasoned about:

| what you do | what the filter does |
|---|---|
| float either pad | **opens** — the brake is released |
| drive both pads low | **holds** position, no current |
| pad A high, pad B low | moves one way |
| pad B high, pad A low | moves the other way |

- **It takes two pads.** The filter is an H-bridge, so `irCutPin1`/`irCutPin2` are the two ends of one bridge, not two switches, and pulsing one alone proves nothing.
- **Two kinds exist.** A *latching* filter stays where a pulse puts it. A *brake-held* one is held by both pads driven low and springs open when they float — which is why majestic keeps those pads exported and driven. It is holding the filter shut, not leaking GPIOs. The article gives a one-step test for which kind you have.
- **`ircut_enabled` is 1 when the filter is OPEN**, tracking the night position rather than "the filter is on". Confirmed by toggling `/night/ircut` in daylight and watching the picture go magenta and back.
- **An absent gauge is not a zero** — a build that omits these publishes nothing, and "no day/night state reported" is a different answer from "day with the filter closed".

Plus what the WebUI now does for you (the pin map, **Find them for me**, **Test the filter**), with the scan's risk stated plainly rather than buried, and a short "if the picture is pink in daylight" list ordered by likelihood — including the case everyone forgets, that night mode is simply on.

### Four corrections

- **`auto-night-mode-without-light-sensor.md`** sent people to an *"IR-cut filter"* button **in the preview**. It isn't there — the Live page is read-only now and the switch is on Settings → Live adjustments. Its Step 1 (judge pinkness by eye, guess the pins are swapped) is exactly what the filter test now decides.
- **`majestic-streamer.md`** presented `isp_again` 1024/32000 as if universal. The same idle, no-extra-gain state reads about **1024 on HiSilicon, 126 on Ingenic, 20855 on SigmaStar** — a threshold copied from a HiSilicon example onto an Ingenic camera simply never trips. Now says to read your own camera first.
- **`majestic-config.md`** documented `nightMode.adcReadout` and `overrideWdr`. Neither appears in `config.schema.json` and both **404 on `/api/v1/set`** on a current build (2.6.08.30), while `overrideDrc` beside them accepts — so it isn't a test artefact. Removed.
- **`gpio-settings.md`**'s column map didn't say the pair's **order** decides direction (a swapped pair gives a correctly-moving filter that is pink in daylight), and didn't mention that the table is now **read by software**: the WebUI's pin scan tries the pairs recorded there before anything else, so a listed board is found in seconds where an unlisted one falls back to a long sweep. Adding a board there now helps the next person and the scanner both.

### Checked

Every relative link resolves, the `#auto-daynight-detection` anchor exists, both removed keys are gone from the sample, and nothing links the retired `wiki.openipc.org` domain. The hardware claims were re-measured on the lab camera while writing this, not recalled.