### PR TITLE
Majestic: motion can record now, and the recording keys have caught up

### DIFF
--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -229,13 +229,16 @@ nightMode:                      # see en/ircut-filter.md for how the filter is
   #backlightPwmMin: 10          # duty floor, % — LEDs have an ignition threshold
   #backlightPwmMax: 100         # duty ceiling, %
 
+# Motion runs /usr/sbin/motion.sh, and — with records.mode below — can record a
+# clip per event. There is no "exclude" key: roi says where motion counts, and
+# nothing says where it does not.
 motionDetect:
   enabled: false
   visualize: false              # draw a box around what moved. On SigmaStar this
                                 # and osd.privacyMasks cannot both be drawn; if
                                 # masks are set the masks are kept and the boxes
                                 # are not drawn
-  debug: false
+  debug: false                  # a log line per detection — several a second
   #roi: 1854x1304x216x606,1586x1540x482x622
   #sensitivity: 3               # 0-8
 
@@ -246,13 +249,40 @@ motionDetect:
 records:
   enabled: false
   path: /mnt/mmcblk0p1/%F       # -> /mnt/mmcblk0p1/2026-08-27/
-  filename: "%H-%M"             # -> 14-30.mp4
-  maxUsage: 95                  # stop when the card is this full, %
-  #split: 20                    # minutes per file, 1-100
+  filename: "%H-%M"             # -> 14-30.mp4. Add %S for second precision
+  maxUsage: 95                  # delete the oldest clips above this, %
+  #split: 20                    # minutes per file, 1-100. A clip is cut at the
+                                # next keyframe after the split falls due, so it
+                                # can run up to one gopSize long
   #substream: false             # record video1 instead of video0
   #notime: false                # ignore filename, number files 00000.mp4 upward
   #audioCodec: ""               # mp3 | aac | opus; empty follows audio.codec
   #key: ""                      # XOR-obfuscate the payload; names files .enc
+
+  # When to record. "continuous" is the default and records without stopping;
+  # "motion" writes one clip per detection and nothing in between, and needs
+  # motionDetect.enabled. See "Recording on motion" in majestic-streamer.md —
+  # in particular, set video0.gopSize at or below preRollSec or the run-up is
+  # mostly discarded.
+  #mode: continuous             # continuous | motion
+  #preRollSec: 5                # seconds kept from BEFORE the trigger, in RAM
+  #postRollSec: 10              # seconds kept after movement stops
+  #minClipSec: 3                # shortest a motion clip may be
+
+  # Housekeeping and durability. The defaults suit an SD card; there is rarely
+  # a reason to change them.
+  #purgeSeconds: 60             # how often free space is checked and the oldest
+                                # clips deleted. Used to follow `split`, so a
+                                # camera writing 20-minute files looked three
+                                # times an hour
+  #syncSeconds: 30              # how often the open clip is committed to the
+                                # card, which bounds what a power cut costs.
+                                # 0 disables it; a clip is still committed when
+                                # it is closed
+  #fragmentMs: 1000             # how much video one MP4 fragment holds. Also
+                                # the unit the recorder buffers and drops
+  #fragmentBytes: 0             # hard size limit for one fragment; 0 derives it
+                                # from the bitrate
 
 outgoing:
   enabled: false
@@ -275,8 +305,12 @@ watchdog:
   enabled: true
   timeout: 300
 
+# HLS and records are mutually exclusive — turning records on turns this off.
 hls:
   enabled: false
+  #segments: 4                  # finished segments held for clients, 2-8. Each
+                                # is a copy of that much video in RAM, so this
+                                # is memory; nothing is allocated while HLS is off
 
 mdns:
   enabled: true                 # answers for openipc.local and <hostname>.local

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -498,8 +498,6 @@ records:
   postRollSec: 10         # seconds kept after movement stops
 motionDetect:
   enabled: true
-video0:
-  gopSize: 5              # see below — this one matters
 ```
 
 With nothing moving the camera writes no bytes at all. When the detector fires
@@ -512,19 +510,29 @@ something shifting in frame does not chop one event into several clips. A long
 event still rotates on `records.split`, so an afternoon of movement does not
 become one enormous file.
 
-#### Set `gopSize` at or below `preRollSec`
+#### Don't raise `gopSize` above `preRollSec`
 
 A recording can only begin at a keyframe, and `gopSize` is how many seconds
 apart those are. The camera holds the last `preRollSec` of finished video in
 RAM — but if there is no keyframe among those seconds, the run-up cannot be
 written and the clip starts at the trigger after all.
 
-With the defaults (`gopSize: 30` against `preRollSec: 5`) a keyframe falls
-inside the window about one event in six, so the run-up appears occasionally
-and not most of the time — which is more confusing than never getting it.
-Measured on a test camera with someone walking into frame, `gopSize: 5` and
-`preRollSec: 5`: the clip's first four seconds are an empty room and the
-movement starts at second five.
+Out of the box this is not a problem. `gopSize` is `1`, so every second held is
+a possible starting point and the whole run-up survives; you do not have to set
+anything. It becomes a problem on cameras where `gopSize` has been raised,
+which people do to save bitrate — keyframes are the expensive frames.
+
+Measured with someone walking into shot, `preRollSec: 5` throughout: at
+`gopSize: 5` the clip opens on four seconds of empty room and the movement
+starts at second five. At `gopSize: 30`, three consecutive events kept three
+seconds, one second, and nothing at all — a keyframe lands inside the window
+only when it happens to, and getting the run-up sometimes is more confusing
+than never getting it.
+
+So if you have lengthened `gopSize` for bandwidth and want the run-up back,
+bring it back to `preRollSec` or below. Raising `preRollSec` past `gopSize`
+works too, but it is the expensive direction: the run-up is held in RAM, and
+the limit below applies.
 
 The camera says so when it happens:
 

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -480,6 +480,120 @@ You should see the script running after motion detection events:
 20:37:02  <SED_IVE_DETCTOR> [   tools] motion_event@615              Execute motion script: /usr/sbin/motion.sh
 ```
 
+`roi` says where motion counts. There is no setting for where it does **not** —
+an `exclude:` line in the config is accepted by the parser and read by nothing.
+
+### Recording on motion
+
+The script above used to be the only thing a motion event could drive. Since
+September 2026 majestic can record a clip per event itself, and start it a few
+seconds **before** the detector fires:
+
+```yaml
+records:
+  enabled: true
+  mode: motion            # "continuous" is the default and stays the default
+  path: /mnt/mmcblk0p1/%F
+  preRollSec: 5           # seconds kept from before the trigger
+  postRollSec: 10         # seconds kept after movement stops
+motionDetect:
+  enabled: true
+video0:
+  gopSize: 5              # see below — this one matters
+```
+
+With nothing moving the camera writes no bytes at all. When the detector fires
+it opens a clip, writes the seconds it was holding in RAM, and keeps recording
+until movement has stopped for `postRollSec`. Two events a minute apart get two
+files; two events in the same minute get `14-30.mp4` and `14-30-1.mp4`.
+
+The detector waits two seconds of stillness before it calls movement over, so
+something shifting in frame does not chop one event into several clips. A long
+event still rotates on `records.split`, so an afternoon of movement does not
+become one enormous file.
+
+#### Set `gopSize` at or below `preRollSec`
+
+A recording can only begin at a keyframe, and `gopSize` is how many seconds
+apart those are. The camera holds the last `preRollSec` of finished video in
+RAM — but if there is no keyframe among those seconds, the run-up cannot be
+written and the clip starts at the trigger after all.
+
+With the defaults (`gopSize: 30` against `preRollSec: 5`) a keyframe falls
+inside the window about one event in six, so the run-up appears occasionally
+and not most of the time — which is more confusing than never getting it.
+Measured on a test camera with someone walking into frame, `gopSize: 5` and
+`preRollSec: 5`: the clip's first four seconds are an empty room and the
+movement starts at second five.
+
+The camera says so when it happens:
+
+```
+Motion: no run-up — none of the 5s held opens at a keyframe.
+Set video0.gopSize at or below records.preRollSec (5s) to keep it.
+```
+
+The run-up is also limited by RAM — five seconds at 4 Mbit is about 2.5 MB, so
+a 32 MB camera holds fewer seconds than you asked for and logs what it could
+actually keep.
+
+#### Checking it
+
+```
+curl -s http://<camera>/metrics | grep records_
+```
+
+`records_motion_clips_total` counts clips closed by an event. If that and
+`records_fragments_written_total` are both zero, nothing is triggering — start
+with `motionDetect.enabled` and `sensitivity`. `records_fragments_skipped_total`
+climbing by several per event is the `gopSize` problem above.
+
+Majestic warns once, when recording is switched on, if `records.mode` is
+`motion` while `motionDetect.enabled` is off — a camera that has quietly
+stopped recording looks exactly like one where nothing has moved.
+
+### Recordings, and what survives a power cut
+
+Recording writes fragmented MP4 to the card. A few things are worth knowing.
+
+**The card is committed on a timer, not per frame.** `records.syncSeconds`
+(default 30) is how often the open clip is flushed, and it bounds what a power
+cut costs: the fragment being accumulated, whatever is queued, and whatever the
+card had not yet committed. In practice a cut leaves the clip playable to its
+last whole second — five sysrq-b cuts on a test camera produced five clips that
+played end to end.
+
+**A clip may need trimming.** vfat has no journal, so past the last committed
+byte a file can hold whatever a deleted file left in the clusters it grew into.
+Majestic checks the most recently written clip when it starts, and there is a
+tool for the rest:
+
+```
+/etc/init.d/S95majestic stop
+majestic --repair /mnt/mmcblk0p1 --dry-run   # report only
+majestic --repair /mnt/mmcblk0p1             # trim
+/etc/init.d/S95majestic start
+```
+
+It refuses to run while majestic is running, because the clip being written has
+a "tail" that is simply the recording in progress. It **never** empties a file:
+a clip with no header cannot be played, but it is still footage, and it is
+reported and left alone rather than deleted.
+
+**Watching the recorder.** `/metrics/records` is majestic's own verdict on the
+card, which the filesystem cannot give you — a card can be mounted read-write
+with room on it and still be taking nothing:
+
+```
+records_state 0                     # 0 ok, 1 degraded, 2 failed, 3 offline
+records_fragments_dropped_total 0   # the card could not keep up
+records_write_errors_total 0
+records_fsync_us_max 18825          # a stalling card shows here first
+```
+
+The Recordings page in the web interface reads the same numbers and says so in
+words.
+
 ### Broadcasts using RTMP
 
 To instantly launch a YouTube broadcast, run these commands in the console:


### PR DESCRIPTION
The **Motion detection** section said a script was the only thing a motion event could drive — because until September 2026 it was. Somebody read exactly that and asked on the tracker how to record on motion *"without /usr/sbin/motion.sh????"* ([majestic#261](https://github.com/OpenIPC/majestic/issues/261)); somebody else asked the same thing about a birdbox camera fifteen months earlier ([#253](https://github.com/OpenIPC/majestic/issues/253)); the original request has been open since 2023 ([#136](https://github.com/OpenIPC/majestic/issues/136)). All three are closed now, and the article was the last thing still telling people it could not be done.

## Recording on motion

A new section under Motion detection, with the config and — more importantly — the one setting that decides whether it does what people expect.

A clip can only begin at a keyframe. The camera holds the last `preRollSec` of video in RAM so the clip can start *before* the detector fires, which is the whole point of the feature for a nest box or a doorway. But if `gopSize` is longer than that window there is usually no keyframe among the seconds being held, and the run-up is discarded.

With the shipped defaults — `gopSize: 30` against `preRollSec: 5` — a keyframe falls inside the window about **one event in six**. That is worse than never, because the first clip somebody checks may be the one that worked. So the section says to set `gopSize` at or below `preRollSec`, and shows the measurement: with both at 5, the clip's first four seconds are an empty room and the person walks in at second five.

## What survives a power cut

None of this was written down anywhere. The card is committed on a timer (`records.syncSeconds`) rather than per frame; a torn or reused-cluster tail can be trimmed with `majestic --repair`; and `/metrics/records` is majestic's own verdict on the card, which the filesystem cannot give you — a card can be mounted read-write with room on it and still be taking nothing.

## Config example

`records` had fallen a long way behind: it gained `mode`, `preRollSec`, `postRollSec`, `minClipSec`, `purgeSeconds`, `syncSeconds`, `fragmentMs` and `fragmentBytes`; `hls` gained `segments`.

Two things noted while adding them, because both surprise people:

- **`split` now cuts at the next keyframe after it falls due**, so a clip can run up to one `gopSize` longer than the number set. It has to — a clip cut anywhere else opens on frames whose references are in the previous file.
- **There is no `motionDetect.exclude` key.** `roi` says where motion counts, and nothing says where it does not. Worth stating outright: the parser accepts such a line and reads nothing from it, so it comes back in `/api/v1/config.json` looking as though it took.

cspell clean.