### PR TITLE
Majestic: SIP is not G.711-only any more, and the mic can be processed

### DIFF
--- a/en/howto-doorbell-from-camera.md
+++ b/en/howto-doorbell-from-camera.md
@@ -21,10 +21,17 @@ hardware up.
 ## What you'll need
 
 - An OpenIPC camera that has a working speaker output and a working
-  mic input. Easiest way to confirm both work end-to-end: open
-  `http://<camera>/audio.ulaw` to verify the mic capture path (uLaw
-  is codec-free, so it needs nothing installed to play), and POST a
-  short raw-audio payload to
+  mic input. Easiest way to confirm the mic capture path is
+  `http://<camera>/audio.html`, the built-in player page, which
+  needs nothing installed. The raw endpoints work too but are
+  headerless, so a player has to be told the format. G.711 is always
+  8 kHz whatever the microphone captures at:
+
+  ```sh
+  ffplay -ar 8000 -ac 1 -f mulaw http://<camera>/audio.ulaw
+  ```
+
+  For the speaker, POST a short raw-audio payload to
   `http://<camera>/play_audio` (the speaker sink) — for example:
 
   ```sh

--- a/en/howto-doorbell-from-camera.md
+++ b/en/howto-doorbell-from-camera.md
@@ -8,8 +8,9 @@ Recent `majestic` builds turn **any OpenIPC camera with a speaker and a
 microphone into a fully-featured SIP doorbell**: press a button, the
 camera dials a configured destination (your phone, your laptop
 softphone, your home PBX), the called side answers, and you get
-one-way video + two-way G.711 audio over a regular SIP call. No
-cloud, no app, no vendor lock-in.
+one-way video + two-way audio over a regular SIP call — Opus when
+the other side takes it, G.711 otherwise. No cloud, no app, no
+vendor lock-in.
 
 This article walks you through a working setup end-to-end, starting
 from zero SIP experience, and finishes with a **debug technique
@@ -22,8 +23,8 @@ hardware up.
 - An OpenIPC camera that has a working speaker output and a working
   mic input. Easiest way to confirm both work end-to-end: open
   `http://<camera>/audio.ulaw` to verify the mic capture path (uLaw
-  is codec-free and matches the audio format the SIP doorbell uses
-  anyway), and POST a short raw-audio payload to
+  is codec-free, so it needs nothing installed to play), and POST a
+  short raw-audio payload to
   `http://<camera>/play_audio` (the speaker sink) — for example:
 
   ```sh
@@ -66,9 +67,9 @@ in the optional section near the end.
 When the visitor presses the button, the camera (acting as a SIP UAC
 — **U**ser **A**gent **C**lient) sends an `INVITE` to your PBX. The
 PBX rings your softphone. You answer, and the camera streams one-way
-H.264 (or H.265) video to you and full-duplex G.711 audio so you can
-hear the visitor and they can hear you. End the call by hanging up,
-or by pressing the doorbell button again (it toggles).
+H.264 (or H.265) video to you and full-duplex audio so you can hear
+the visitor and they can hear you. End the call by hanging up, or by
+pressing the doorbell button again (it toggles).
 
 ## Step 1 — Set up a SIP destination
 
@@ -120,6 +121,13 @@ max_contacts=2
 # Repeat the [1001] block for 1002, 1003, ... — one per device.
 ```
 
+`ulaw`/`alaw` are enough — the camera falls back to G.711 whenever the
+other side does not offer anything better. If you want the wideband
+option, add `allow=opus` to the endpoint template; on Asterisk that
+needs the Opus module (`res_format_attr_opus`, plus `codec_opus` if
+the PBX has to transcode rather than pass through), so leave it out
+until you have confirmed it loads.
+
 Minimal `/etc/asterisk/extensions.conf`:
 
 ```ini
@@ -155,8 +163,6 @@ sections:
 ```yaml
 audio:
   enabled: true            # mic capture
-  codec: ulaw              # PCMU — also try alaw if your PBX prefers
-  srate: 8000
   outputEnabled: true      # speaker
   outputVolume: 60         # 0..100; bump until you can hear yourself
   jitterBufferMs: 60       # 0 = LAN-only; see "Going remote" below
@@ -187,6 +193,21 @@ sip:
   buttonPin: 12            # the GPIO you wired the button to
   buttonActiveLow: true    # `true` = button pulls the pin to ground when pressed
 ```
+
+> **`audio.codec` and `audio.srate` are not SIP settings.** A call
+> negotiates its own codec on the wire: majestic offers Opus and
+> G.711 in one `m=audio` line and uses whichever the other side
+> picks, without ever reading `audio.codec`. That key selects the
+> codec for RTSP, recordings and the `/audio.*` endpoints, so
+> setting it to `ulaw` for the doorbell's sake only makes everything
+> *else* on the camera narrowband.
+>
+> `audio.srate` is likewise free. G.711 is 8 kHz on the wire by
+> definition, and the encoder resamples to it from whatever the
+> microphone is capturing, so a camera at 48 kHz makes correct calls
+> *and* keeps full-bandwidth recordings. Older builds did not
+> resample and needed `srate: 8000`; if calls sound sped-up or
+> distorted, that is the version to check.
 
 `killall -HUP majestic` to reload — this picks up `sip.*` changes as of the
 2026-08 builds; older ones needed a full restart of majestic, and quietly left
@@ -440,9 +461,11 @@ What each field means:
    speaker. Lower `outputVolume`, or physically separate the mic and
    speaker on the PCB.
 3. **`488 Not Acceptable Here` from the PBX.** Codec mismatch. The
-   camera advertises `ulaw` (PCMU) by default; if your PBX is
-   restricted to a different codec, change `audio.codec` accordingly
-   or add `allow=ulaw` to your PBX endpoint config.
+   camera offers Opus and G.711 together and takes whichever the PBX
+   picks, so this means the PBX accepts neither — widen its codec
+   list (`allow=ulaw` or `allow=alaw` on the endpoint is enough).
+   Changing `audio.codec` will not help: the SIP stack does not read
+   it, and lowering it only narrows RTSP and your recordings.
 4. **Call connects but no audio.** Almost always RTP firewall /
    NAT. Make sure UDP `rtpPortHint`..`rtpPortHint+3` (i.e. four
    ports) is reachable from the called side. For NAT traversal,

--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -191,6 +191,21 @@ audio:
   #jitterBufferMs: 80           # RTSP back-channel: 0 = passthrough (LAN),
                                 # 80 helps over Wi-Fi/WAN
 
+# (build-dependent: Ultimate, and only on some SoCs — see "Microphone
+# processing (VQE)" in Majestic streamer). Runs on the capture channel, so one
+# setting reaches RTSP, SIP, WebRTC, the /audio.* endpoints and recordings
+# alike. All of it is inside the audio: section above.
+  #vqe: false                   # master switch for the three stages below
+  #anr: true                    # noise reduction (8/16 kHz only)
+  #anrIntensity: 25             # 0-25
+  #anrNoiseThreshold: 41        # 30-60 dB
+  #agc: true                    # automatic gain control
+  #agcTargetLevel: -1           # -40..-1 dBFS
+  #agcNoiseFloor: -42           # dBFS; -65..-20 at 8/16 kHz, -50..-20 at 48 kHz
+  #agcMaxGain: 20               # 0-30 dB
+  #hpf: true                    # high-pass filter
+  #hpfFreq: 80                  # 80 | 120 | 150 Hz; 48 kHz has 80 only
+
 rtsp:
   enabled: true
   port: 554

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -55,6 +55,7 @@ the web interface, the HTTP API and HTTPS.
 | Microphone, speaker, `/audio.*` endpoints | — | ✅ | ✅ |
 | Opus, AAC, G.711 A-law / µ-law, raw PCM | — | ✅ | ✅ |
 | [MP3][mp3] audio (`/audio.mp3`, `audio.codec: mp3`) | — | — | ✅ |
+| [Microphone processing](#microphone-processing-vqe) — noise reduction, AGC, high-pass (`audio.vqe`) | — | — | ✅¹ |
 | [WebP][webp] snapshots (`/image.webp`) | — | — | ✅ |
 | Crop and greyscale snapshots on any SoC, without `jpeg.tuned` ([`/image.jpg?crop=`](#crop-and-gray-on-ultimate)) | — | — | ✅ |
 | [Progressive][prog] snapshots (`jpeg.toProgressive`) | — | — | ✅ |
@@ -65,6 +66,9 @@ the web interface, the HTTP API and HTTPS.
 | Cloud signalling (`cloud.enabled`) | — | ✅ | ✅ |
 | SIP client (the doorbell use case) | — | ✅ | ✅ |
 | RTMP and RTMPS push (YouTube, Telegram, VK…) | — | ✅ | ✅ |
+
+¹ Not on every Ultimate camera — the SoC has to have the engines this is
+written against. See [Microphone processing (VQE)](#microphone-processing-vqe).
 
 The one thing FPV gains in exchange is room. Measured on a Goke GK7205V200,
 same commit, same toolchain, stripped:
@@ -642,8 +646,11 @@ The outgoing stream sends an audio codec the RTMP container supports, converting
 from `audio.codec` when needed, so `audio.codec` can stay on Opus for RTSP while
 the broadcast still carries audio a service accepts. To pin a specific codec set
 `outgoing.audioCodec` (`aac`, `alaw`, `ulaw`, `pcm`); leave it empty to follow
-`audio.codec`. For A-law and mu-law the RTMP container is fixed at 8 kHz, so set
-`audio.srate: 8000` or the audio plays back at the wrong speed.
+`audio.codec`. A-law and mu-law are 8 kHz by definition and the encoder
+resamples to it from whatever the microphone is capturing, so `audio.srate` can
+stay wherever the rest of the camera wants it. Builds before 2026-09 did not
+resample and needed `audio.srate: 8000` here, or the audio played back at the
+wrong speed.
 
 If the camera has no microphone, `outgoing.audioSource` supplies a track anyway:
 
@@ -856,6 +863,79 @@ curl -u root:YOUR_PASSWORD --data-binary @test.pcm http://192.168.1.10/play_audi
 This is a one-shot clip player: a new upload cancels the clip currently playing,
 and the clip is capped at roughly 2 MB on most SoCs (about two minutes at
 8 kHz). For a live conversation use two-way audio below.
+
+### Microphone processing (VQE)
+
+*Ultimate, and only on some SoCs.* HiSilicon and Goke parts carry a voice
+quality enhancement block on the audio input channel — noise reduction (ANR),
+automatic gain control (AGC) and a high-pass filter. Majestic can switch it on:
+
+```
+audio:
+  enabled: true
+  vqe: true
+```
+
+It sits on the **capture** channel, upstream of every encoder, so one setting
+reaches RTSP, SIP calls, WebRTC, the `/audio.*` endpoints and MP4 recordings
+alike. There is nothing per-protocol to configure and nothing that can
+disagree.
+
+Off by default: it changes how every stream from the camera sounds, and an
+upgrade should not move that under a camera someone has already tuned by ear.
+The shipped values are the ones a vendor firmware uses on this class of SoC, so
+turning it on lands somewhere known to work.
+
+Which stages you get depends on `audio.srate`, because the SoC has two engines
+and they are not interchangeable:
+
+| `audio.srate` | engine | ANR | AGC | high-pass |
+|---|---|:---:|:---:|:---:|
+| 8000, 16000 | talk | ✅ | ✅ | 80 / 120 / 150 Hz |
+| 48000 | record | — | ✅ | 80 Hz only |
+| 32000 | *neither* | — | — | — |
+
+At 32 kHz there is no engine at all; majestic logs that and carries on rather
+than pretending. The tuning keys are listed in
+[Majestic example config](majestic-config.md).
+
+#### Which cameras actually have it
+
+Two conditions, and both have to hold. The build must be Ultimate, **and** the
+SoC must be one of the three generations these SDK calls belong to. Of the
+chips Ultimate is published for:
+
+| chip | SoC code | VQE |
+|---|---|:---:|
+| Hi3516EV200 | 3516E200 | ✅ |
+| GK7205V200 | 7205200 | ✅ |
+| GK7205V500 | 7205500 | — |
+| Hi3516CV200 | 3518E200 | — |
+| Hi3516CV300 | 3516C300 | — |
+
+The older parts have a differently shaped SDK call and are not wired up. If
+your camera is not on the ✅ list the keys simply will not exist, and
+`curl http://localhost/api/v1/config.json` will not list them.
+
+Majestic also builds this for SoC code 3516C500 — the Hi3516CV500 / AV300 /
+DV300 family — but no Ultimate image is published for those chips today, so
+in practice the two above are the whole list.
+
+#### If the keys are there but nothing changes
+
+The DSP stages are separate shared libraries that the SDK loads at the moment
+VQE is switched on, and firmware images built before this feature existed do
+not carry them. Then the log says:
+
+```
+the SoC would not start the talk VQE engine (0xa0158041) — audio continues
+unprocessed. The stages are loaded by dlopen at this point, so the usual cause
+is a firmware image built without the VQE engine libraries
+```
+
+and the console shows `dlopen ... libhive_HPF.so failed`. Audio keeps flowing
+normally; only the processing is missing. The fix is a firmware image that
+installs those libraries — update the firmware, don't change majestic.
 
 ### Two-way audio (talkback)
 

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -801,10 +801,17 @@ image format.
 Use [ffplay][ffplay] utility from [ffmpeg][ffmpeg] package.
 ```
 ffplay -ar 48000 -ac 1 -f s16le http://192.168.1.10/audio.pcm
-ffplay -ar 48000 -ac 1 -f alaw http://192.168.1.10/audio.alaw
-ffplay -ar 48000 -ac 1 -f mulaw http://192.168.1.10/audio.ulaw
+ffplay -ar 8000 -ac 1 -f alaw http://192.168.1.10/audio.alaw
+ffplay -ar 8000 -ac 1 -f mulaw http://192.168.1.10/audio.ulaw
 ffplay -ar 8000 -ac 1 -f alaw http://192.168.1.10/audio.g711a
 ```
+
+`-ar` has to match what the endpoint emits. `/audio.pcm` follows
+`audio.srate` — 48000 above is only an example, use whatever the camera is set
+to. The G.711 endpoints are always 8 kHz: that is the rate the codec is defined
+at, and the encoder resamples to it from whatever the microphone captures.
+Builds before 2026-09 passed the capture rate through unchanged, so on those
+`-ar` had to match `audio.srate` here too.
 
 There are also `/audio.opus` and `/audio.m4a` (AAC), which ffplay reads without
 being told the rate, and `/audio.mp3` in Ultimate builds. `/audio.html` is a


### PR DESCRIPTION
An audit of the wiki's Majestic SIP and audio coverage turned up three things that are wrong against merged behaviour, plus a feature documented nowhere. All four are fixed here.

## SIP is not G.711-only any more

`majestic` offers Opus and G.711 in one `m=audio` line and uses whichever the far end picks. The doorbell how-to said "two-way G.711 audio" in the intro, the call-flow walkthrough, and the `/audio.ulaw` aside.

## The how-to asked readers to break their own camera

This is the one worth reading carefully. Step 3 said:

```yaml
audio:
  codec: ulaw              # PCMU — also try alaw if your PBX prefers
  srate: 8000
```

and the `488 Not Acceptable Here` entry repeated it ("change `audio.codec` accordingly").

Neither key has ever been a SIP setting, and following that advice costs you real quality:

* **`audio.codec`** selects the codec for RTSP, the `/audio.*` endpoints and recordings. The SIP stack builds its own SDP offer and never reads it. Setting it to `ulaw` for the doorbell's benefit only makes *everything else* on the camera narrowband.
* **`audio.srate`** was a genuine constraint once. It is not now: G.711 encoding resamples to 8 kHz from whatever the microphone captures (the fix patched the encoders, not the callers), so a camera at 48 kHz makes correct calls **and** keeps full-bandwidth recordings.

That second one is exactly the tradeoff a user reported having to make — good recordings or working calls, pick one — and the page was still asking for it after the fix landed.

Both are replaced with a short note explaining why there is no codec or rate line in the SIP config, and the 488 entry now points at the PBX's codec list, which is where the actual mismatch is.

The same stale 8 kHz requirement was repeated for A-law/µ-law RTMP push in `majestic-streamer.md` and is corrected there too.

## VQE was documented nowhere

New in majestic — noise reduction, AGC and a high-pass filter on the microphone capture channel. It gets the config keys, a row in the flavour table, and a section of its own.

Two things about it will generate questions otherwise, so both are stated plainly:

**It is Ultimate *and* SoC-gated**, which works out to two of the five chips Ultimate is published for:

| chip | SoC code | VQE |
|---|---|:---:|
| Hi3516EV200 | 3516E200 | ✅ |
| GK7205V200 | 7205200 | ✅ |
| GK7205V500 | 7205500 | — |
| Hi3516CV200 | 3518E200 | — |
| Hi3516CV300 | 3516C300 | — |

(Majestic also builds it for 3516C500, but no Ultimate image is published for that family, so it does not reach anyone today.)

**The keys can exist and the feature still do nothing.** The DSP stages are shared libraries the SDK `dlopen`s on demand, and images built before OpenIPC/firmware#2361 do not carry them. The section quotes the log line that says so and points at a firmware update rather than at any majestic setting.

## Deliberately not included

The three genuinely undocumented `audio.*` keys — `device`, `dual`, `extern` — are unconditional in the schema but absent from `majestic-config.md`, which bills itself as "a reference of what exists". Left for a separate pass so this PR stays about the stale SIP advice and the new feature.

Also noted while auditing, well out of scope here: `ru/` has no Majestic documentation at all.

