### PR TITLE
tinyCam how-to: drop a link into a repository readers cannot open

### DIFF
--- a/en/howto-tinycam-onvif.md
+++ b/en/howto-tinycam-onvif.md
@@ -100,9 +100,8 @@ those calls, and shows a live stream.
   fixed `80`, and that ONVIF is enabled (`onvif.enabled=true`).
 - **Auth still fails with the password set, on older firmware.** Some older
   majestic builds could not parse tinyCam's ONVIF token because it uses an XML
-  *default namespace* rather than a `wsse:` prefix. If you hit this, update to a
-  current OpenIPC firmware. (Reference: majestic
-  [PR #400](https://github.com/widgetii/majestic/pull/400).)
+  *default namespace* rather than a `wsse:` prefix. This was fixed in majestic
+  in August 2026, so if you hit it, update to a current OpenIPC firmware.
 
 ### Why PasswordDigest, specifically
 


### PR DESCRIPTION
The tinyCam ONVIF page cited a majestic pull request for the namespace-parsing fix, by URL. majestic's source repository is private, so that link answers 404 for every reader of this wiki — a citation nobody can follow, pointing at a tracker whose numbering is not public either.

The fact it supported is worth keeping and now stands on its own: the fix landed in August 2026, so a current OpenIPC firmware has it. That is what a reader hitting the symptom actually needs, and unlike the link it is something they can act on.

Mine, from the page's original commit (0a0c4340).

## Why this and nothing else

Found by sweeping all 165 pages of this wiki for the same class of disclosure, after the equivalent cleanup in `OpenIPC/majestic-webui` (#333). This link is the only hit. Specifically clean:

- **no source paths** from a sibling repository (`src/<vendor>/…`) in any page
- **no firmware symbol names** — the config walker, the SDK reload, the placement routines and friends appear nowhere
- **no lab environment** — no camera hostname, no private address

Three other matches for the same search are not disclosures and are left alone: `@widgetii` twice as a person's contact handle (the credits table in `en/menu-index.md` and a quoted message in `ru/discussion-buildroot.md`), and a public gist link in `en/notes-for-resorting.md`. A username and a gist are not the private repository.
