### PR TITLE
Majestic: say who is allowed to call the camera

### DIFF
--- a/en/howto-doorbell-from-camera.md
+++ b/en/howto-doorbell-from-camera.md
@@ -216,6 +216,13 @@ sip:
 > resample and needed `srate: 8000`; if calls sound sped-up or
 > distorted, that is the version to check.
 
+> **Who may call the camera.** Registering, as above, is also what tells the
+> camera whose calls to accept: it takes them from the PBX in `sip.server` and
+> refuses everyone else, with nothing extra to configure. If you set
+> `doRegister: false` you have to say instead — `sip.allowedPeers` for the
+> addresses that may call without a password, or `sip.authInbound` to ask for
+> one. See [Who may call the camera](majestic-streamer.md#who-may-call-the-camera).
+
 `killall -HUP majestic` to reload — this picks up `sip.*` changes as of the
 2026-08 builds; older ones needed a full restart of majestic, and quietly left
 SIP switched off until they got one. The interesting log lines:
@@ -301,6 +308,11 @@ leg and a pair of RTP ports); a longer list is still fine in sequential mode.
 > at its own address, so the numbers can live on different machines — as long
 > as each one is written as a literal IP. Hostnames still go to `sip.server`,
 > because resolving them at call time would stall the video pipeline.
+>
+> Direct-dial mode is also the one that has to say who may call *in*. A camera
+> that registers trusts its PBX and needs nothing; one that does not has no
+> registrar to trust, so add `sip.allowedPeers` with the handsets' addresses —
+> see [Who may call the camera](majestic-streamer.md#who-may-call-the-camera).
 
 ## Controlling calls over HTTP
 
@@ -473,14 +485,26 @@ What each field means:
    list (`allow=ulaw` or `allow=alaw` on the endpoint is enough).
    Changing `audio.codec` will not help: the SIP stack does not read
    it, and lowering it only narrows RTSP and your recordings.
-4. **Call connects but no audio.** Almost always RTP firewall /
+4. **`403 Forbidden` or `401 Unauthorized` on a call *to* the camera.**
+   The camera is deciding who may call it. A registering camera takes
+   calls from its PBX only; one with `doRegister: false` takes them
+   from `sip.allowedPeers`, or asks for a password when
+   `sip.authInbound` is on. The log names the caller and the remedy —
+   grep for `sip uac: refused a call from`. See
+   [Who may call the camera](majestic-streamer.md#who-may-call-the-camera).
+5. **`481 Call/Transaction Does Not Exist` on a BYE or CANCEL.** The
+   request did not identify the call it was ending: a BYE has to carry
+   the dialog's tags and a CANCEL has to name the INVITE's `Via`
+   branch. A conformant peer sends both, so this usually means
+   something is replaying an old message.
+6. **Call connects but no audio.** Almost always RTP firewall /
    NAT. Make sure UDP `rtpPortHint`..`rtpPortHint+3` (i.e. four
    ports) is reachable from the called side. For NAT traversal,
    point the camera at a SIP server that does media relay (TURN /
    ICE) or run the PBX on the same LAN as the camera.
-5. **Choppy audio on Wi-Fi or 4G.** Set `audio.jitterBufferMs` to
+7. **Choppy audio on Wi-Fi or 4G.** Set `audio.jitterBufferMs` to
    `60` or higher. See the "Going remote" table above.
-6. **`sip uac: REGISTER failed (401)` loop.** Wrong password, or
+8. **`sip uac: REGISTER failed (401)` loop.** Wrong password, or
    the PBX expects a different `realm`. The exact challenge realm
    is in the log; some PBXes require `username` to match the From
    user, others a separate auth ID.

--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -374,6 +374,15 @@ cloud:
   #ringSeconds: 10              # 1-300
   #ringCycles: 3                # 0-100 passes over the target list; 0 = forever
 
+  # Who may call this camera. A camera that registers already trusts its
+  # registrar and refuses everyone else, so these are for deployments with no
+  # registrar to trust. See "Who may call the camera" in Majestic streamer.
+  #allowedPeers: ""             # addresses allowed to call in, e.g.
+                                # "192.168.1.50, 192.168.9.0/24"
+  #authInbound: false           # ask everyone else for a password instead
+  #inboundUser: ""              # falls back to sip.username
+  #inboundPassword: ""          # falls back to sip.password
+
 # (build-dependent: Lite and Ultimate)
 #webrtc:
   # https://www.w3.org/TR/webrtc/#rtciceserver-dictionary with optional

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -944,6 +944,73 @@ and the console shows `dlopen ... libhive_HPF.so failed`. Audio keeps flowing
 normally; only the processing is missing. The fix is a firmware image that
 installs those libraries — update the firmware, don't change majestic.
 
+### Who may call the camera
+
+The SIP client answers calls as well as placing them, which makes the camera
+reachable from anywhere that can send it a UDP packet. Since the 2026-09
+builds it decides who is allowed to do that.
+
+**A camera that registers needs no configuration for this.** It trusts the
+registrar it was pointed at — the PBX in `sip.server` — and refuses everyone
+else. That is the setup the [doorbell guide](howto-doorbell-from-camera.md)
+describes, and nothing in it changes.
+
+Deployments with no registrar to trust say who may call, in one of two ways:
+
+```
+sip:
+  # either: name the addresses, and they call without a password
+  allowedPeers: "192.168.1.50, 192.168.9.0/24"
+
+  # or: ask everyone for one
+  authInbound: true
+  inboundPassword: "something-long"     # falls back to sip.password
+```
+
+`allowedPeers` takes dotted-quad addresses and CIDR ranges, separated by
+commas or spaces. `authInbound` challenges with SIP Digest, which every
+softphone and PBX can answer; `inboundUser` and `inboundPassword` fall back to
+`sip.username` and `sip.password`, so a doorbell that already has a PBX login
+does not need a second one invented for it.
+
+The two combine: an address in `allowedPeers` is never asked for a password,
+everybody else is asked if `authInbound` is on and refused with `403` if not.
+Liveness probes (`OPTIONS`) are always answered, because a PBX that cannot
+qualify the camera marks it unreachable and quietly stops routing calls to it.
+
+`system.unsafe` switches this off along with everything else.
+
+#### If the camera stops answering after an upgrade
+
+One deployment changes behaviour: `doRegister: false` with callers that used
+to be accepted because nothing was checking. Those need one of the two keys
+above. The camera says so at start-up, and this is the line to grep for:
+
+```
+sip uac: nothing may call this camera — it does not register, sip.allowedPeers
+is empty and sip.authInbound is off, so every inbound call will be refused. Set
+sip.allowedPeers to the caller's address, or sip.authInbound to ask it for a
+password
+```
+
+Refusals name the caller too, so `sip uac: refused a call from` tells you which
+address to add. Both keys are picked up by `killall -HUP majestic`.
+
+To go back to answering anyone — knowing what that means — set
+`allowedPeers: "0.0.0.0/0"`.
+
+#### What this does not protect
+
+SIP Digest is MD5 over UDP with no integrity protection, so it stops somebody
+who can reach the port, not somebody who can already read your traffic. Its
+real job is making an inbound call from an unknown address *possible at all*
+without leaving the camera open to everyone.
+
+Two things do not depend on it, and are worth knowing about because they used
+to be missing: a `BYE` must carry the dialog's tags before it ends a call, and
+a `CANCEL` must name the transaction it cancels. Previously a Call-ID copied
+off the wire was enough to do either.
+
 ### Two-way audio (talkback)
 
 #### RTSP back-channel, ONVIF Profile T


### PR DESCRIPTION
Documents the inbound SIP authorisation added in widgetii/majestic#593. The wiki currently says nothing about who may call the camera, in either the old state (anyone) or the new one.

## The headline is that nothing changes for the documented setup

A camera that registers trusts the PBX in `sip.server` and refuses everyone else — **no configuration at all**. Every doorbell built from the how-to keeps working untouched, so the guide's step count does not grow.

## What needed writing

**A new section, "Who may call the camera"** in `majestic-streamer.md`, covering the deployment that does change: `doRegister: false` has no registrar to trust, so it has to say who may call — `sip.allowedPeers` for addresses that need no password, or `sip.authInbound` to ask for one.

It quotes the start-up line a camera nobody can reach now prints, because that line names both keys and is what somebody will actually grep for when calls stop arriving:

```
sip uac: nothing may call this camera — it does not register, sip.allowedPeers
is empty and sip.authInbound is off, so every inbound call will be refused. Set
sip.allowedPeers to the caller's address, or sip.authInbound to ask it for a
password
```

**The doorbell guide** points at it twice — from Step 3, where registering is configured, and from the direct-dial passage, which is the mode that needs a key.

**Two troubleshooting entries:** `403`/`401` on a call *to* the camera, and `481` on a BYE or CANCEL. The second is new behaviour worth being able to recognise — a BYE must now carry the dialog's tags and a CANCEL must name the INVITE's `Via` branch, where a Call-ID copied off the wire used to be enough to end somebody else's call.

**The four new keys** are in the config reference, with the fallback (`inboundUser`/`inboundPassword` → `sip.username`/`sip.password`) spelled out.

## Honest about the limit

The section says plainly that Digest here is MD5 over UDP with no integrity protection, so it stops somebody who can reach the port, not somebody who can already read your traffic — and that the dialog and transaction checks are the part that does not depend on it.

It also documents `allowedPeers: "0.0.0.0/0"` as the way back to answering anyone, for people who want that deliberately.

Depends on widgetii/majestic#593; the keys do not exist before it.
