### PR TITLE
Majestic: HLS runs beside recording now, and describes it

### DIFF
--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -328,11 +328,19 @@ watchdog:
 # card, which costs no memory and puts the live edge about a second behind.
 hls:
   enabled: false
+  #adaptive: false              # offer both encoder channels as two variants and
+                                # let the player choose. Only the recorded channel
+                                # comes from the card, so the second one is held in
+                                # RAM: this is the setting that costs memory
   #segments: 4                  # finished segments the playlist offers, 2-8.
                                 # Only a memory cost when there is no recording
                                 # to describe — with records off, or records.key
                                 # set, each segment is held in RAM instead.
                                 # Nothing is allocated while HLS is off
+                                #
+                                # records.mode: motion turns this off: nothing
+                                # is written between detections, so there would
+                                # be no live stream to serve
 
 mdns:
   enabled: true                 # answers for openipc.local and <hostname>.local

--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -323,12 +323,16 @@ watchdog:
   enabled: true
   timeout: 300
 
-# HLS and records are mutually exclusive — turning records on turns this off.
+# Applies without a restart, and runs alongside records rather than instead of
+# it — with recording on, the playlist describes byte ranges of the clip on the
+# card, which costs no memory and puts the live edge about a second behind.
 hls:
   enabled: false
-  #segments: 4                  # finished segments held for clients, 2-8. Each
-                                # is a copy of that much video in RAM, so this
-                                # is memory; nothing is allocated while HLS is off
+  #segments: 4                  # finished segments the playlist offers, 2-8.
+                                # Only a memory cost when there is no recording
+                                # to describe — with records off, or records.key
+                                # set, each segment is held in RAM instead.
+                                # Nothing is allocated while HLS is off
 
 mdns:
   enabled: true                 # answers for openipc.local and <hostname>.local

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -704,9 +704,18 @@ of holding a second copy of every segment in RAM, so:
   so a player does not have to wait for the next keyframe before it has
   something to fetch.
 
-With recording off, or with `records.key` set — which scrambles the clips, so
-their bytes are not what a player needs — HLS falls back to keeping segments in
-memory. It still works; it is just the expensive way round.
+HLS falls back to keeping segments in memory whenever there is no clip to
+describe: with recording off, and with `records.key` set — which scrambles the
+clips, so their bytes are not what a player needs. It still works; it is just
+the expensive way round.
+
+`records.mode: motion` is refused rather than served badly. Between detections
+nothing is written, so there would be no new byte ranges to describe and the
+live edge would simply stop until something moved — which looks like a broken
+stream, not like a setting anyone chose. Turning motion recording on therefore
+turns `hls.enabled` off, and says so in the log; the settings page shows the
+HLS switch as unavailable while the recorder is in motion mode. A camera that
+has to do both is a camera that wants `records.mode: continuous`.
 
 #### Low latency
 
@@ -730,15 +739,37 @@ Players that do not implement blocking reload simply poll, and still get the
 
 #### Segment length follows gopSize
 
-A segment runs from one keyframe to the next, so `video0.gopSize` sets it. At
-`gopSize: 30` the segments are thirty seconds long, which makes a player slow
-to start and each segment large; at `gopSize: 1` they are a second. Parts make
-the *live edge* independent of that, but segment size is not, so a camera
-serving HLS to players without low-latency support wants a shorter GOP than one
-that is only recording.
+A segment runs from one keyframe to the next, so the recorded stream's
+`gopSize` sets it — `video0.gopSize` normally, and `video1.gopSize` when
+`records.substream: true`, because HLS describes whichever channel is being
+written. At `gopSize: 30` the segments are thirty seconds long, which makes a
+player slow to start and each segment large; at `gopSize: 1` they are a second.
+Parts make the *live edge* independent of that, but segment size is not, so a
+camera serving HLS to players without low-latency support wants a shorter GOP
+than one that is only recording.
 
 `hls.segments` sets how many finished segments the playlist offers, 2 to 8. It
-is only a memory cost in the fall-back case above.
+is only a memory cost in the fall-back cases above.
+
+#### Offering both streams
+
+`hls.adaptive` puts both encoder channels in the master playlist, as two
+variants with their own resolutions and bitrates, and the player picks whichever
+its connection can carry and switches between them as that changes. Without it
+the playlist has one variant: whichever channel is being recorded.
+
+The second variant is not free, and the price is the memory the recorded one
+stopped costing. Only the recorded channel can be described out of the clip on
+the card; the other is held in RAM the older way, so `malloc_hls_alloc_bytes`
+goes from 0 to roughly `hls.segments` multiplied by a GOP of that channel. On a
+camera whose second channel runs a thirty-second GOP that is megabytes, and a
+shorter `gopSize` on that channel is what brings it down.
+
+It is also video only. The recorded variant carries the audio; duplicating it in
+both would be work for something a player takes from whichever variant it is
+playing.
+
+Both settings apply without a restart, `hls.enabled` included.
 
 ### Broadcasts using RTMP
 

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -713,9 +713,10 @@ the expensive way round.
 nothing is written, so there would be no new byte ranges to describe and the
 live edge would simply stop until something moved — which looks like a broken
 stream, not like a setting anyone chose. Turning motion recording on therefore
-turns `hls.enabled` off, and says so in the log; the settings page shows the
-HLS switch as unavailable while the recorder is in motion mode. A camera that
-has to do both is a camera that wants `records.mode: continuous`.
+turns `hls.enabled` off, and says so in the log; the settings page explains it
+under the HLS switch while the recorder is in motion mode, rather than letting
+the two be set against each other and leaving the result to be discovered. A
+camera that has to do both is a camera that wants `records.mode: continuous`.
 
 #### Low latency
 

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -673,6 +673,73 @@ records_fsync_us_max 18825          # a stalling card shows here first
 The Recordings page in the web interface reads the same numbers and says so in
 words.
 
+### Live HLS
+
+`hls.enabled` turns on an HLS stream at `/master.m3u8`, with a player page at
+`/hls`. It applies immediately — no restart, and recording is not interrupted
+while you switch it on or off.
+
+```yaml
+hls:
+  enabled: true
+records:
+  enabled: true       # optional, and worth having: see below
+```
+
+**HLS and recording used to be mutually exclusive.** They are not any more, and
+running both is the better configuration rather than merely a permitted one.
+
+#### Why recording makes HLS cheaper and faster
+
+A recording on the card is already the format HLS serves. When the camera is
+recording, the playlist describes byte ranges of the clip it is writing instead
+of holding a second copy of every segment in RAM, so:
+
+- **it costs no memory.** `malloc_hls_alloc_bytes` in `/metrics` reads 0 while
+  HLS is served this way. With recording off it reads the size of the window
+  instead — `hls.segments` multiplied by however much video a GOP is, which at
+  a long `gopSize` and a high bitrate is tens of megabytes;
+- **the live edge is about a second behind**, not a whole GOP. The playlist
+  carries `EXT-X-PART` entries for the part of the stream still being written,
+  so a player does not have to wait for the next keyframe before it has
+  something to fetch.
+
+With recording off, or with `records.key` set — which scrambles the clips, so
+their bytes are not what a player needs — HLS falls back to keeping segments in
+memory. It still works; it is just the expensive way round.
+
+#### Low latency
+
+The stream advertises `CAN-BLOCK-RELOAD=YES`, so a player that supports
+Low-Latency HLS can ask for a playlist that does not exist yet and have the
+request held until it does, rather than polling for it:
+
+```
+GET /video.m3u8?_HLS_msn=<segment>&_HLS_part=<part>
+```
+
+The camera answers the moment that part is written, so the wait is one part —
+about a second, since a part is `records.fragmentMs` long and that defaults to
+1000. A request for something more than one segment ahead is refused with 400
+rather than held, and one that waits more than six seconds is answered with
+504, which means the stream has stalled rather than that the player asked for
+the wrong thing.
+
+Players that do not implement blocking reload simply poll, and still get the
+`EXT-X-PART` entries.
+
+#### Segment length follows gopSize
+
+A segment runs from one keyframe to the next, so `video0.gopSize` sets it. At
+`gopSize: 30` the segments are thirty seconds long, which makes a player slow
+to start and each segment large; at `gopSize: 1` they are a second. Parts make
+the *live edge* independent of that, but segment size is not, so a camera
+serving HLS to players without low-latency support wants a shorter GOP than one
+that is only recording.
+
+`hls.segments` sets how many finished segments the playlist offers, 2 to 8. It
+is only a memory cost in the fall-back case above.
+
 ### Broadcasts using RTMP
 
 To instantly launch a YouTube broadcast, run these commands in the console:


### PR DESCRIPTION
Three things changed for anyone using HLS, and the configuration reference still said the opposite of the first.

**HLS and records are no longer mutually exclusive.** The comment above the `hls:` block promised that turning records on would turn HLS off. That was true and is not any more, and running both is now the better configuration rather than merely a permitted one.

**`hls.enabled` applies without a restart**, in either direction, and recording carries on across the change.

**With recording on, the playlist describes byte ranges of the clip being written** rather than holding a second copy of every segment in RAM. Two consequences an operator can see:

- `malloc_hls_alloc_bytes` in `/metrics` reads **0** instead of the tens of megabytes a long GOP at a high bitrate costs;
- the live edge is **about a second** behind instead of a whole GOP, because the playlist carries `EXT-X-PART` entries for the segment still being written.

With records off, or `records.key` set — which scrambles the clips, so their bytes are not what a player needs — it falls back to keeping segments in memory. That is the old behaviour, and the expensive way round.

The new **Live HLS** section in the streamer guide also covers blocking playlist reload (`_HLS_msn`/`_HLS_part`, the 400 and 504 cases), and says plainly that **segment length still follows `video0.gopSize`** even though the live edge no longer does. A camera serving players without low-latency support wants a shorter GOP than one that is only recording, and that is not obvious from either setting on its own.

Every number quoted was measured on a lab hi3516av300 rather than derived from the code. Kept to configuration keys, endpoints, playlist tags and metric names — nothing about how any of it is implemented.
