### PR TITLE
Majestic: idle suspension of the sensor and ISP, and a restart that was never needed

### DIFF
--- a/en/auto-night-mode-without-light-sensor.md
+++ b/en/auto-night-mode-without-light-sensor.md
@@ -66,6 +66,11 @@ After stopping the script, you can run `/usr/sbin/autonight.sh` manually in a te
 Metrics are displayed at the `/metrics` endpoint in the web interface.
 
 _The current analog gain value is displayed in `isp_again`:_
+
+> On HiSilicon and Goke with `isp.suspendWhenIdle` switched on, the ISP
+> gauges — `isp_again` among them — are omitted while the camera is
+> idle-suspended, because there is no running ISP to read them from. They
+> come back with the picture.
 ```
 # HELP isp_again Analog Gain
 # TYPE isp_again gauge

--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -56,6 +56,9 @@ isp:
   #pad: 0                       #                           (SigmaStar)
   #yuvCompression: auto         # HiSilicon gen 3/4 only; saves ~1/3 of the main
                                 # frame buffer, ignored with rotate/mirror/masks
+  #suspendWhenIdle: false       # HiSilicon/Goke: stop the sensor and ISP when
+                                # nothing wants frames -- see majestic-streamer.md
+  #suspendIdleSeconds: 5        # grace period before it does, 1-300
   # Manual exposure and gain. Each is skipped when absent, so leaving it out
   # keeps the automatic behaviour.
   #exposure: 0                  #                (HiSilicon/Goke, SigmaStar, Ingenic)

--- a/en/majestic-encoder-tuning.md
+++ b/en/majestic-encoder-tuning.md
@@ -199,14 +199,18 @@ answers `404` rather than accepting a setting nothing would apply.
 
 The reference structure is programmed between encoder channel creation and the
 start of encoding; the SDK ignores a later call. That does *not* mean you have
-to restart anything. Setting either key restarts the video pipeline on its own
-and the new value is picked up as encoding starts again, so this is enough:
+to restart anything. Setting either key is enough on its own:
 
 ```
 curl 'http://localhost/api/v1/set?video0.refEnhance=1'
 ```
 
-Majestic is not restarted and the camera does not reboot. The real cost is that
-the streams drop and come back, so viewers see a reconnect — do it when that is
-acceptable, not while something is recording. Confirm the new setting took
-effect with the bitrate check above rather than assuming it did.
+Majestic is not restarted and the camera does not reboot. What you will see is
+the streams drop and come back, so viewers reconnect — do it when that is
+acceptable, not while something is recording.
+
+Read the value back afterwards rather than assuming it was taken:
+
+```
+curl 'http://localhost/api/v1/config.json' | grep -A2 refEnhance
+```

--- a/en/majestic-encoder-tuning.md
+++ b/en/majestic-encoder-tuning.md
@@ -198,5 +198,15 @@ answers `404` rather than accepting a setting nothing would apply.
 ### Applying changes
 
 The reference structure is programmed between encoder channel creation and the
-start of encoding; the SDK ignores a later call. A config reload is not enough —
-restart majestic, or reboot the camera, for these to take effect.
+start of encoding; the SDK ignores a later call. That does *not* mean you have
+to restart anything. Setting either key restarts the video pipeline on its own
+and the new value is picked up as encoding starts again, so this is enough:
+
+```
+curl 'http://localhost/api/v1/set?video0.refEnhance=1'
+```
+
+Majestic is not restarted and the camera does not reboot. The real cost is that
+the streams drop and come back, so viewers see a reconnect — do it when that is
+acceptable, not while something is recording. Confirm the new setting took
+effect with the bitrate check above rather than assuming it did.

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -216,8 +216,10 @@ the frame is rejected with `400` rather than quietly ignored. A crop or a
 greyscale conversion asked for while another one is still running is answered
 with `503`: that transformation *is* the request, so the camera says come back
 shortly rather than send an uncropped picture as if nothing had happened. A
-plain `/image.jpg` with no parameters is unaffected by any of this and always
-works.
+plain `/image.jpg` with no parameters is unaffected by any of this. The one
+thing that does stop it is
+[idle suspension](#stopping-the-sensor-and-isp-when-nothing-is-watching), which
+is off unless you turn it on.
 
 ### Changing parameters via the HTTP API
 
@@ -389,6 +391,11 @@ isp:
   suspendIdleSeconds: 5   # grace period, 1-300
 ```
 
+These arrived in the nightly builds of 5 September 2026. A build without them
+answers `404` to the API and does not show them in the web interface, so if the
+keys are missing the firmware is older than the feature rather than the camera
+being unsupported.
+
 Audio, RTSP, the web server and the API keep running throughout, so a camera
 stays reachable, keeps answering its API and keeps streaming its microphone
 while its sensor is asleep. Enabling a stream brings the picture back.
@@ -429,9 +436,9 @@ Four behaviours worth knowing before turning it on:
   `isp_exptime` and the rest are readings from a stopped ISP, so they are
   omitted rather than reported stale. `node_hwmon_temp_celsius` and the memory
   gauges stay.
-- **It saves power, not memory.** The frame pool is fixed when the streamer
-  starts and is not returned by a suspend — see
-  [Memory tuning](memory-tuning.md) for what actually frees blocks.
+- **It saves power, not memory.** A suspended camera holds the same memory as a
+  running one — see [Memory tuning](memory-tuning.md) for what actually frees
+  any.
 
 Motion detection counts as wanting frames, so a camera with
 `motionDetect.enabled` never suspends.

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -376,6 +376,66 @@ day: the trim stops dimming well above the day threshold, so only real dawn
 ends the night. The current percentage is the `night_light_duty` gauge on
 `/metrics`, and the dashboard's day/night line shows it as "lamp 43%".
 
+### Stopping the sensor and ISP when nothing is watching
+
+Turning both video streams off stops the *encoders*, but the sensor and the
+image pipeline behind them keep running, and that is where most of the power
+goes. On HiSilicon and Goke the camera can stop the sensor and its image
+pipeline as well, and not just the encoders:
+
+```yaml
+isp:
+  suspendWhenIdle: true   # default false
+  suspendIdleSeconds: 5   # grace period, 1-300
+```
+
+Audio, RTSP, the web server and the API keep running throughout, so a camera
+stays reachable, keeps answering its API and keeps streaming its microphone
+while its sensor is asleep. Enabling a stream brings the picture back.
+
+Measured at the PoE port on a Hi3516EV300 + IMX335, with both streams and audio
+configured, averaged over 60 samples per state:
+
+| state | power drawn | die temperature |
+| --- | --- | --- |
+| both encoders streaming + audio | 2.06 W | 62.1 °C |
+| both encoders disabled, sensor and ISP still running | 1.77 W | 56.2 °C |
+| **idle-suspended** | **1.01 W** | 49.5 °C |
+
+Suspending halves the draw. Stopping the encoders alone accounts for 0.29 W of
+that and stopping the sensor and ISP for a further 0.77 W, which is why the setting
+exists at all — the second saving is nearly three times the first, and nothing
+before this could reach it. Temperature understates the difference badly, so
+judge this by current if you can measure it. The figures are draw at the port,
+so they include the losses in the splitter and the cable; the board's own rail
+is lower, and the ratio is the part that carries to a battery.
+
+**It is off by default, deliberately.** A camera already in the field should not
+begin power-cycling its sensor because somebody switched off a sub-stream.
+
+Four behaviours worth knowing before turning it on:
+
+- **Waking costs about two seconds of picture quality.** The sensor comes back
+  with no exposure history, so auto-exposure starts from its default and
+  converges. Frames arrive immediately and are correctly formed — they are
+  simply overexposed while the loop closes. If you drive the camera from an
+  external trigger, enable the stream slightly before the footage matters.
+- **A snapshot will not wake it, a viewer will.** `/image.jpg` while suspended
+  answers `503` with a message naming the setting, so a monitoring system
+  polling for stills cannot keep a battery camera awake for ever. A client that
+  stays connected to `/mjpeg`, or to MJPEG over RTSP, *does* wake it, and the
+  camera goes back to sleep once that client leaves.
+- **The ISP gauges leave `/metrics` while it is asleep.** `isp_again`,
+  `isp_exptime` and the rest are readings from a stopped ISP, so they are
+  omitted rather than reported stale. `node_hwmon_temp_celsius` and the memory
+  gauges stay.
+- **It saves power, not memory.** The frame pool is fixed when the streamer
+  starts and is not returned by a suspend — see
+  [Memory tuning](memory-tuning.md) for what actually frees blocks.
+
+Motion detection counts as wanting frames, so a camera with
+`motionDetect.enabled` never suspends.
+
 ### On-screen display and privacy masks
 
 Two different things share the `osd` section, and they answer to different
@@ -759,6 +819,11 @@ description. ONVIF snapshot URIs and the web interface preview both fetch
 `/image.jpg`, so they stop working too. See
 [Memory tuning](memory-tuning.md#jpegenabled--snapshots-and-the-mjpeg-stream)
 for what it frees.
+
+`jpeg.enabled` is not the only reason for that `503`. A camera running with
+`isp.suspendWhenIdle` answers the same status while its sensor is asleep, with
+a different message and a different remedy — enable a video stream. See
+[Stopping the sensor and ISP when nothing is watching](#stopping-the-sensor-and-isp-when-nothing-is-watching).
 
 Turning on `jpeg.rtsp` publishes the same MJPEG as an RTSP stream. RFC 2435
 caps that at 2040 px per axis, so a larger `jpeg.size` is reduced to 1280x720

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -410,7 +410,7 @@ configured, averaged over 60 samples per state:
 | **idle-suspended** | **1.01 W** | 49.5 °C |
 
 Suspending halves the draw. Stopping the encoders alone accounts for 0.29 W of
-that and stopping the sensor and ISP for a further 0.77 W, which is why the setting
+that and stopping the sensor and ISP for a further 0.76 W, which is why the setting
 exists at all — the second saving is nearly three times the first, and nothing
 before this could reach it. Temperature understates the difference badly, so
 judge this by current if you can measure it. The figures are draw at the port,

--- a/en/memory-tuning.md
+++ b/en/memory-tuning.md
@@ -215,7 +215,9 @@ pipeline puts **into** it, and the settings that change how much it takes.
 These are applied like any other setting, through the HTTP API described in
 [Majestic streamer](majestic-streamer.md). They differ from most in one
 respect worth knowing: they decide how the video pipeline's buffers are laid
-out, so changing one rebuilds the pipeline and the stream drops for a moment.
+out, so changing one rebuilds the pipeline and every stream drops for a moment.
+`videoN.enabled` is the exception — it is applied to its own channel alone, and
+viewers of the other stream stay connected.
 
 All of the region's usage is visible at runtime:
 
@@ -274,6 +276,14 @@ moment, because the pool is fixed when the streamer starts — a channel raised 
 demand still needs its block sitting there waiting. That is why switching a
 channel off is worth more than any amount of tuning: `video1.enabled: false` and
 `jpeg.enabled: false` each return a full frame.
+
+Both of those free their frame for the *next* start rather than immediately:
+the pool keeps whatever size it was given when the streamer came up, so
+switching a stream off on a running camera does not hand its block back. The
+figures above are what you measure after a restart. The same holds for
+[idle suspension](majestic-streamer.md#stopping-the-sensor-and-isp-when-nothing-is-watching),
+which stops the sensor and ISP outright — a large power saving, and not a
+memory one at all.
 
 Which of those applies is decided by the sensor's width, not by the model of
 SoC, and it is why two cameras with the same chip can need different amounts:


### PR DESCRIPTION
Two unrelated things, one commit each.

## `isp.suspendWhenIdle` had no documentation at all

It ships in tonight's nightly (OpenIPC/majestic#298) and the wiki said nothing about it, which had also quietly dated three other pages.

**New section on the streamer page**, placed with the other sensor-side behaviour next to day/night and the backlight. The numbers in it are draw measured at the PoE port on a lab hi3516ev300 + IMX335, sixty samples a state:

| state | power drawn | die temperature |
| --- | --- | --- |
| both encoders streaming + audio | 2.06 W | 62.1 °C |
| both encoders disabled, front end still running | 1.77 W | 56.2 °C |
| **idle-suspended** | **1.01 W** | 49.5 °C |

That is the point of the feature and the reason it earns a section rather than two lines in the config reference: suspending halves the draw, where switching the encoders off — everything that was possible before — accounts for less than a third of the saving. Temperature understates it badly, so the section says to judge by current.

Four behaviours are documented because each one will otherwise surprise somebody: waking costs about two seconds while auto-exposure reconverges; a snapshot poll deliberately cannot wake the camera but a connected `/mjpeg` viewer can; the ISP gauges leave `/metrics` while the sensor is asleep; and it saves power, not memory.

**Three consequences elsewhere:**

- The JPEG section gave `jpeg.enabled` as *the* reason `/image.jpg` answers `503`. There are two now, with different remedies.
- The auto-night-mode page teaches readers to look for `isp_again` on `/metrics` — one of the gauges omitted while suspended. A note beats leaving someone hunting for a missing line.
- Memory tuning could reasonably leave a reader expecting a suspend to free memory. It does not; the pool is sized when the streamer starts. That paragraph also picks up the fact that `videoN.enabled` is applied live now and no longer costs every other viewer their stream.

## The reference structure never needed a restart

Unrelated to the above and older than it, which is why it is a separate commit.

The encoder-tuning page said a config reload was not enough for `refEnhance` and `refPred`, and that Majestic had to be restarted or the camera rebooted. Neither is true: setting either key through the API restarts the video pipeline on its own and the new value is picked up as encoding starts again — which is exactly the moment the same paragraph says it has to happen. Checked on hardware; the majestic process is never restarted.

The page now names the cost that is real — the streams drop and come back, so viewers see a reconnect — and points at the bitrate check it already documents for confirming the setting took. The paragraph's first sentence was correct and is kept.