### PR TITLE
Review gates: make the disclosure rule a check instead of a promise

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -60,8 +60,9 @@ something the pull request did not set out to document.
 
 compliance_user_guidelines = """
 Apply pr_compliance_checklist.yaml literally, to the lines the diff adds or changes AND
-to the pull request's own title and description — the disclosure gate is about what
-becomes public, and a pull request description is as public as the page.
+to the commit messages on the branch, the pull request's title and its description —
+the disclosure gate is about what becomes public, and all of those are as public as
+the page. A commit message is the one that cannot be edited afterwards at all.
 
 Do not raise a finding for pre-existing text that the diff merely moves or rewraps.
 """

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,67 @@
+# Qodo code-review configuration.
+#
+# The binary hard gates live in a companion file at the repo root:
+#   pr_compliance_checklist.yaml
+#
+# Reference: https://docs.qodo.ai/install-and-configure/configuration-overview/configuration-file
+
+[github_app]
+pr_commands = [
+    "/agentic_describe",
+    "/agentic_review",
+]
+
+[review_agent]
+comments_location_policy = "both"
+
+# 1 = all severities inline, 2 = high+medium, 3 = high only.
+# 2 keeps disclosure findings inline without burying a documentation diff in nits.
+inline_comments_severity_threshold = 2
+
+issues_user_guidelines = """
+This repository is the OpenIPC wiki: user-facing documentation for camera firmware,
+the software that runs on it, and the hardware it runs on. Readers are operators and
+integrators, not the people who build it. Pages are Markdown under en/ and ru/.
+
+**This repository is PUBLIC, and not everything it documents is.** Majestic in
+particular is developed in a repository that is not open. Treat a page that explains
+how a closed component is built, rather than what it does, as a finding in its own
+right — see the disclosure gate in pr_compliance_checklist.yaml, the highest-priority
+check here and the only one that cannot be fixed after merge.
+
+Prioritise, in order:
+
+1. Disclosure. Internals of a component whose source is not public, and any detail
+   identifying the lab hardware used to verify a claim. Permanent once merged: a
+   commit message on a public branch cannot be rewritten, and editing a merged pull
+   request's description leaves the original visible in its history.
+
+2. Claims a reader cannot check, and claims that are simply wrong. This wiki's
+   recurring failure is a confident instruction nobody has retested since the software
+   changed — most often a stated requirement to restart or reboot for something that
+   now applies on its own, or a setting described with a default it no longer has. A
+   page that tells the reader how to confirm a result for themselves is worth more
+   than one that asserts it.
+
+3. Completeness where behaviour has more than one cause. When a page enumerates why
+   something happens — why an endpoint returns a particular status, why a feature is
+   unavailable — a newly added cause belongs in that list, not only in the section
+   introducing it. Half-updated enumerations send readers to the wrong remedy.
+
+4. Coverage claims. Where a feature exists only on some SoCs, builds or firmware
+   versions, say which, and say it where a reader on unsupported hardware will see it
+   before acting.
+
+Do not report: British or American spelling preferences, Markdown table alignment,
+line-length or wrapping style, the ru/ pages lagging behind en/ (they are translated
+when a translator is available, not per pull request), or the absence of a page for
+something the pull request did not set out to document.
+"""
+
+compliance_user_guidelines = """
+Apply pr_compliance_checklist.yaml literally, to the lines the diff adds or changes AND
+to the pull request's own title and description — the disclosure gate is about what
+becomes public, and a pull request description is as public as the page.
+
+Do not raise a finding for pre-existing text that the diff merely moves or rewraps.
+"""

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -33,9 +33,12 @@ pr_compliances:
       behaviour a user sees — including caveats and things that will surprise them.
       Where the mechanism genuinely helps a reader, it is given in ordinary language
       for the thing it is ("the camera stops the sensor and its image pipeline"),
-      never in the vocabulary the source uses for itself.
+      never in the vocabulary the source uses for itself. A screenshot is held to
+      the same standard as prose: what it shows on screen is as published as the
+      paragraph beside it.
     failure_criteria: >
-      A page, a commit message, the title or the description, concerning a closed
+      Anything the merge publishes — a page, an image or other committed artifact,
+      a commit message, the title or the description — concerning a closed
       component, adds any of: a source path
       or file name from its tree; a function, macro, struct or enum identifier from it;
       an internal subsystem name used as though it were a term of art the reader should

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -6,7 +6,12 @@
 # all developed in the open. They are the only checks here whose violation cannot be
 # undone after merge: a commit message on a public branch cannot be rewritten, and
 # editing a merged pull request's description leaves the original visible in its edit
-# history. They apply to the diff AND to the pull request's own title and description.
+# history.
+#
+# So they apply to everything the merge makes public, not only the pages: the diff,
+# the commit messages on the branch, and the pull request's own title and description.
+# The commit message is the easiest of those to forget and the hardest to take back --
+# a description can at least be edited, however visibly.
 #
 # Schema: https://docs.qodo.ai/v1/features/custom-compliance
 
@@ -30,7 +35,8 @@ pr_compliances:
       for the thing it is ("the camera stops the sensor and its image pipeline"),
       never in the vocabulary the source uses for itself.
     failure_criteria: >
-      A page, title or description about a closed component adds any of: a source path
+      A page, a commit message, the title or the description, concerning a closed
+      component, adds any of: a source path
       or file name from its tree; a function, macro, struct or enum identifier from it;
       an internal subsystem name used as though it were a term of art the reader should
       know; the name of an internal classification or state scheme the product applies
@@ -56,8 +62,8 @@ pr_compliances:
       a command. Where an address is ours rather than the reader's, it is a
       placeholder, a documentation domain, or an RFC 5737 example range.
     failure_criteria: >
-      The diff, the title or the description adds something identifying the project's
-      own test hardware or network: a lab host's name or domain, an address on the lab
+      The diff, a commit message on the branch, the title or the description adds
+      something identifying the project's own test hardware or network: a lab host's name or domain, an address on the lab
       network presented as a real machine a reader could reach, a login belonging to a
       specific lab device rather than a documented factory default, an SSH alias or
       config stanza reaching one, an unreleased build's branch name or commit id, or

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -49,11 +49,17 @@ pr_compliances:
     success_criteria: >
       A measurement or verification is described by hardware class and configuration —
       the SoC, the sensor, the stream settings, how many samples over how long — which
-      is what makes the result reproducible by someone else. Any address a reader needs
-      is a placeholder, a documentation domain, or an RFC 5737 example range.
+      is what makes the result reproducible by someone else. Addresses and credentials
+      that belong to the product rather than to us are exactly what this wiki is for
+      and are unaffected: the address a camera ships on, the login a fresh device
+      accepts, what a factory reset restores, and the example ranges pages use to show
+      a command. Where an address is ours rather than the reader's, it is a
+      placeholder, a documentation domain, or an RFC 5737 example range.
     failure_criteria: >
-      The diff, the title or the description adds a lab host's name or domain, a
-      private IP literal presented as real, a credential or a default password, an SSH
-      alias or config stanza reaching one, an unreleased build's branch name or commit
-      id, or console output, log text or screenshots captured from a lab device and
+      The diff, the title or the description adds something identifying the project's
+      own test hardware or network: a lab host's name or domain, an address on the lab
+      network presented as a real machine a reader could reach, a login belonging to a
+      specific lab device rather than a documented factory default, an SSH alias or
+      config stanza reaching one, an unreleased build's branch name or commit id, or
+      console output, log text or screenshots captured from a lab device and
       identifiable as such.

--- a/pr_compliance_checklist.yaml
+++ b/pr_compliance_checklist.yaml
@@ -1,0 +1,59 @@
+# Hard gates for OpenIPC wiki pull requests.
+#
+# These are binary pass/fail checks, deliberately narrow and objective.
+#
+# Both exist because this repository is PUBLIC and documents software that is not
+# all developed in the open. They are the only checks here whose violation cannot be
+# undone after merge: a commit message on a public branch cannot be rewritten, and
+# editing a merged pull request's description leaves the original visible in its edit
+# history. They apply to the diff AND to the pull request's own title and description.
+#
+# Schema: https://docs.qodo.ai/v1/features/custom-compliance
+
+pr_compliances:
+  - title: "Documents behaviour, not the internals behind it"
+    compliance_label: true
+    objective: >
+      Some of what this wiki documents is developed in repositories that are not
+      public, Majestic among them. A page describing how one is built rather than what
+      it does discloses a design its readers were not given, and does so permanently.
+      It is also the less useful page: internals are the part that changes without
+      notice, so a sentence resting on one stops being true while the behaviour it
+      was trying to explain stays exactly the same.
+    success_criteria: >
+      Statements about a closed component describe what an operator can observe,
+      configure or measure from outside it: configuration keys with their defaults and
+      ranges, HTTP endpoints and the status codes they return, metric names, timings,
+      measured power or temperature with the method used to obtain them, and the
+      behaviour a user sees — including caveats and things that will surprise them.
+      Where the mechanism genuinely helps a reader, it is given in ordinary language
+      for the thing it is ("the camera stops the sensor and its image pipeline"),
+      never in the vocabulary the source uses for itself.
+    failure_criteria: >
+      A page, title or description about a closed component adds any of: a source path
+      or file name from its tree; a function, macro, struct or enum identifier from it;
+      an internal subsystem name used as though it were a term of art the reader should
+      know; the name of an internal classification or state scheme the product applies
+      to its own settings or components; a description of a vendor SDK call sequence or
+      register-level mechanism; a verbatim log line quoted as a thing to grep for; or
+      the name or URL of a private repository or a reference into a private tracker.
+      This criterion deliberately gives no examples: an example here would be the
+      disclosure it prohibits.
+
+  - title: "No lab environment details"
+    compliance_label: true
+    objective: >
+      The cameras used to verify what these pages claim are private infrastructure.
+      Publishing how to reach one, or what one printed, hands an address and a
+      credential to every reader of a public repository, permanently.
+    success_criteria: >
+      A measurement or verification is described by hardware class and configuration —
+      the SoC, the sensor, the stream settings, how many samples over how long — which
+      is what makes the result reproducible by someone else. Any address a reader needs
+      is a placeholder, a documentation domain, or an RFC 5737 example range.
+    failure_criteria: >
+      The diff, the title or the description adds a lab host's name or domain, a
+      private IP literal presented as real, a credential or a default password, an SSH
+      alias or config stanza reaching one, an unreleased build's branch name or commit
+      id, or console output, log text or screenshots captured from a lab device and
+      identifiable as such.


### PR DESCRIPTION
Qodo already reviews pull requests in this repository, but it has no compliance rules here, so it has nothing to check disclosure against.

That gap showed up in #509. A page documenting a closed component went in describing how that component is *built* — its internal subsystem boundary, the vocabulary its own source uses for itself, the mechanism underneath, and a log line quoted as something to grep for. Qodo reviewed the pull request and said nothing about any of it, correctly, because nothing had told it to look. A human caught it before merge. That is not a control, and it is the one class of mistake that cannot be undone afterwards.

## Two gates

Mirrors the pair [OpenIPC/majestic-webui](https://github.com/OpenIPC/majestic-webui) adopted for the same reason, pointing the other way: that repository is public and must not reference a private one; this repository is public and must not explain what a private one is made of.

**Documents behaviour, not the internals behind it.** Says what a page about a closed component *may* state — configuration keys with defaults and ranges, endpoints and status codes, metric names, measured figures with the method used to get them, and the behaviour a reader will meet, caveats included. That is both the safe half and the more useful half: internals are the part that changes without notice, so a sentence resting on one goes stale while the behaviour it was explaining stays put.

**No lab environment details.** Keeps hostnames, addresses and credentials for the hardware that verifies these claims out of a public tree, while still asking for the SoC, the sensor and the sample count — which is what makes a measurement reproducible by someone else.

Both apply to a pull request's title and description as well as its diff. A description is as public as the page, and neither can be taken back: a commit message on a public branch cannot be rewritten, and editing a merged description leaves the original in its edit history.

The disclosure criterion deliberately gives no examples, and says so in the text. Writing one down would be the disclosure it prohibits — a trap the sibling repository fell into in the very commit that introduced its own version of this rule, which is a fair measure of how easy the mistake is.

## `.pr_agent.toml`

Carries the half that is judgement rather than pass/fail: review priorities with disclosure first, then the failure this wiki actually accumulates — a confident instruction nobody retested after the software changed. That is how a page came to insist on a restart that had stopped being necessary, also fixed in #509.

It also lists what *not* to report, so a documentation review is not spent on spelling variants, table alignment, or the `ru/` pages lagging behind `en/`.