### PR TITLE
docs: what encrypted recordings protect, and how to open one afterwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ OpenIPC Wiki
 - [Majestic encoder tuning](en/majestic-encoder-tuning.md)
 - [Majestic usage research](en/majestic-research.md)
 - [Majestic plugins](en/majestic-plugins.md)
+- [Encrypted recordings on the SD card](en/recording-encryption.md)
 - [Web interface](en/web-interface.md)
 - [Factory reset and the unclaimed camera](en/first-boot.md)
 - [Upgrade firmware](en/sysupgrade.md)

--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -237,7 +237,14 @@ records:
   #substream: false             # record video1 instead of video0
   #notime: false                # ignore filename, number files 00000.mp4 upward
   #audioCodec: ""               # mp3 | aac | opus; empty follows audio.codec
-  #key: ""                      # XOR-obfuscate the payload; names files .enc
+  #encryption: none             # none | passphrase | chip | pubkey -- see
+                                # en/recording-encryption.md; a mode the camera
+                                # cannot honour stops recording, it never falls
+                                # back to writing in the clear
+  #key: ""                      # the passphrase, for encryption: passphrase
+  #publicKey: ""                # PEM public key: the only slot in pubkey mode,
+                                # a recovery key in the other two
+  #chipSlot: 1                  # which OTP key slot chip mode uses (1-3)
 
 outgoing:
   enabled: false

--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -242,9 +242,9 @@ records:
                                 # cannot honour stops recording, it never falls
                                 # back to writing in the clear
   #key: ""                      # the passphrase, for encryption: passphrase
-  #publicKey: ""                # PEM public key: the only slot in pubkey mode,
-                                # a recovery key in the other two
-  #chipSlot: 1                  # which OTP key slot chip mode uses (1-3)
+  #publicKey: ""                # PEM public key: required by pubkey mode, and a
+                                # recovery key in the other two
+  #chipSlot: 1                  # which of the chip's key slots to use (1-3)
 
 outgoing:
   enabled: false

--- a/en/recording-encryption.md
+++ b/en/recording-encryption.md
@@ -20,12 +20,14 @@ unset, the clips are being written in the clear and Majestic says so in the log.
 |---|---|---|---|---|
 | the card was pulled, or copied | readable | as strong as the passphrase | unreadable elsewhere | unreadable elsewhere |
 | the flash was cloned, `majestic.yaml` included | readable | **readable** | unreadable | unreadable |
-| the camera was stolen, and somebody has a shell on it | readable | readable | **readable** | unreadable |
-| the camera died, or the passphrase was lost | readable | readable | **lost** without a recovery key | readable with your private key |
+| the camera was stolen, and somebody has a shell on it | readable | readable | **readable** | unreadable (clips already closed) |
+| the camera died or was replaced | readable | readable, with the passphrase | **lost** without a recovery key | readable with your private key |
+| the passphrase or private key was lost | readable | **lost** | **lost** without a recovery key | **lost** |
 | plays in the web interface | yes | not yet | no | no |
 
-Only `pubkey` survives a stolen camera, and it is the one mode where the camera
-cannot play its own recordings. Everything else keeps something on the camera
+Only `pubkey` survives a stolen camera — for the clips already written, not for
+the one still open — and it is the one mode where the camera cannot play its own
+recordings. Everything else keeps something on the camera
 that opens the clip — and whoever has the camera has that too.
 
 ### The file is still an MP4
@@ -53,16 +55,17 @@ records:
   key: "a long passphrase"
 ```
 
-The passphrase is stretched with PBKDF2-HMAC-SHA256 (100 000 rounds, about a
-second on the camera, done once) and wraps each clip's key.
+The passphrase is stretched into a key-wrapping key — deliberately slowly, which
+is why the first clip after a restart takes about a second to start — and that
+wraps each clip's own key.
 
 It does **not** protect a stolen camera: the passphrase is in `majestic.yaml`,
 and anyone who can read the flash can read it. Use it when the risk you are
 addressing is a card walking out of a device that stays put.
 
-To open a clip, on your own machine, using
-[`tools/records_key.py`](https://github.com/OpenIPC/majestic/blob/master/tools/records_key.py)
-(standard library only, no dependencies):
+To open a clip, on your own machine, with `records_key.py` — the offline
+recovery tool published with Majestic, which needs only a Python 3 install and
+never touches the camera:
 
 ```
 records_key.py dump clip.mp4                                # what this clip carries
@@ -75,6 +78,7 @@ ffmpeg -decryption_key <that key> -i clip.mp4 -c copy clear.mp4
 
 ```yaml
 records:
+  enabled: true
   encryption: pubkey
   publicKey: /etc/records-owner.pub
 ```
@@ -113,6 +117,7 @@ and only after a key has been burned into the chip.
 
 ```yaml
 records:
+  enabled: true
   encryption: chip
   chipSlot: 1
   publicKey: /etc/records-owner.pub   # strongly recommended, see below
@@ -153,8 +158,11 @@ exactly as in the `pubkey` section above.
 
 - **Live streams.** RTSP, HLS, WebRTC and snapshots serve plaintext to whoever
   authenticates. This is about the card, not the network.
-- **A camera that is running.** The key is in RAM or in the engine while it
-  records; only `pubkey` gives a thief nothing.
+- **The clip being written right now.** Its key is in RAM, or in the crypto
+  engine, for as long as that clip is open — in every mode, `pubkey` included.
+  What `pubkey` protects is the recordings already closed on the card; someone
+  who takes a running camera and gets a shell still has the current clip, the
+  live video, and everything recorded from then on.
 - **Metadata.** File names carry the time, sizes carry the bitrate, and the frame
   boundaries stay readable. Someone with the card knows when the camera recorded
   and roughly how much was moving — not what.
@@ -168,15 +176,16 @@ exactly as in the `pubkey` section above.
 - **Changing the mode costs up to one GOP of video.** The new clip has to start
   on a keyframe, so on a camera with a 30-second GOP you lose up to 30 seconds at
   the switch. Change it when nothing important is happening.
-- **The cost while recording** is about 7% of one CPU core per MB/s written —
-  roughly 3-4% of a core at 4 Mbit/s on a hi3516av300, most of it the integrity
-  chain rather than the cipher. `chip` and `passphrase` cost the same, because
-  both use the crypto engine where the camera has one.
+- **The cost while recording** is about 7% of one CPU core per MB/s written, so
+  roughly 3-4% of a core at 4 Mbit/s on a Cortex-A7 class SoC. Most of that is
+  the integrity chain rather than the cipher, and `chip` and `passphrase` cost
+  the same, because both use the crypto engine where the camera has one. Measure
+  your own: sum `utime`+`stime` across `/proc/$(pidof majestic)/task/*/stat` over
+  a minute with encryption off, then again with it on, at the same bitrate.
 - **The web interface cannot play these yet.** Encrypted clips download and open
   on your own machine with the recipes above.
 
 ### See also
 
 - [Majestic example config](majestic-config.md) — the whole `records:` block
-- [`docs/recording-encryption.md`](https://github.com/OpenIPC/majestic/blob/master/docs/recording-encryption.md)
-  — the format, the box layout, and the threat model in detail
+- [Majestic streamer](majestic-streamer.md) — what else the recorder can do

--- a/en/recording-encryption.md
+++ b/en/recording-encryption.md
@@ -27,24 +27,26 @@ unset, the clips are being written in the clear and Majestic says so in the log.
 
 Only `pubkey` survives a stolen camera — for the clips already written, not for
 the one still open — and it is the one mode where the camera cannot play its own
-recordings. Everything else keeps something on the camera
-that opens the clip — and whoever has the camera has that too.
+recordings. Everything else keeps something on the camera that opens the clip,
+and whoever has the camera has that too.
 
 ### The file is still an MP4
 
-Whatever the mode, an encrypted recording is an ordinary fragmented MP4 using
-Common Encryption (`cenc`, AES-128-CTR), keeps its `.mp4` name, and plays with:
+Whatever the mode, an encrypted recording is an ordinary MP4 using the standard
+Common Encryption scheme players already understand. It keeps its `.mp4` name,
+and given the key it plays with:
 
 ```
 ffmpeg -decryption_key <32 hex characters> -i clip.mp4 -c copy clear.mp4
 ```
 
-Each clip has its own key, drawn when the file is opened, and carries that key
-inside itself — wrapped, once per configured mode. Nothing on the camera has to
-remember which key went with which file, and no key is ever reused.
+Every clip has its own key and carries what is needed to open it, so there is no
+key database to keep, nothing to back up per file, and no key shared between two
+recordings.
 
-Every fragment also carries a chained HMAC, so a clip that was cut, reordered or
-edited is detectable. `records_key.py verify` reports how far the chain holds.
+A clip that has been cut short, edited or had parts reordered can be told apart
+from an intact one; the recovery tool reports how much of a clip it can vouch
+for.
 
 ### `passphrase` — protects a card somebody removed
 
@@ -55,24 +57,25 @@ records:
   key: "a long passphrase"
 ```
 
-The passphrase is stretched into a key-wrapping key — deliberately slowly, which
-is why the first clip after a restart takes about a second to start — and that
-wraps each clip's own key.
+Turning the passphrase into a key is deliberately slow, which is why the first
+clip after a restart takes about a second to begin. It happens once, not per
+clip.
 
 It does **not** protect a stolen camera: the passphrase is in `majestic.yaml`,
 and anyone who can read the flash can read it. Use it when the risk you are
 addressing is a card walking out of a device that stays put.
 
-To open a clip, on your own machine, with `records_key.py` — the offline
-recovery tool published with Majestic, which needs only a Python 3 install and
-never touches the camera:
+To open a clip you copy it to your own machine and use Majestic's offline
+recovery tool (`--help` lists its commands; it needs Python 3 and never talks to
+the camera). Give it the clip and the passphrase and it prints the clip's key,
+which is what `ffmpeg` wants:
 
 ```
-records_key.py dump clip.mp4                                # what this clip carries
-records_key.py verify --passphrase 'a long passphrase' clip.mp4
-records_key.py unwrap  --passphrase 'a long passphrase' clip.mp4   # prints the hex key
-ffmpeg -decryption_key <that key> -i clip.mp4 -c copy clear.mp4
+ffmpeg -decryption_key <the key it printed> -i clip.mp4 -c copy clear.mp4
 ```
+
+The same tool tells you what a clip carries and whether it is intact, which is
+worth running before you need it in earnest.
 
 ### `pubkey` — protects a stolen camera
 
@@ -92,20 +95,15 @@ scp owner.pub root@camera:/etc/records-owner.pub
 ```
 
 Each clip's key is sealed to that public key. The camera has no private half, by
-design, so nothing on it — not root, not a flash image, not the crypto engine —
+design, so nothing on it — not the root account, not a copy of its flash —
 can open a recording. That is the point, and the costs follow from it: the
 camera cannot play its own clips, and after a restart it records beside the
 interrupted clip rather than resuming it.
 
-Recovery needs the private key, and never the camera:
-
-```
-records_key.py unwrap --rsa-blob blob.bin clip.mp4
-openssl pkeyutl -decrypt -inkey owner.pem -in blob.bin -out material.bin \
-    -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256 -pkeyopt rsa_mgf1_md:sha256
-records_key.py verify --material material.bin clip.mp4
-records_key.py unwrap --material material.bin clip.mp4      # the hex key for ffmpeg
-```
+Recovery needs the private key, and never the camera. The recovery tool extracts
+the sealed blob from the clip and prints the exact `openssl pkeyutl -decrypt`
+line to run against it; feed what openssl produces back to the tool and it prints
+the clip's key for `ffmpeg`. Three commands, none of which involve the camera.
 
 **Keep `owner.pem` somewhere you will still have it in three years.** Lose it and
 every clip ever written in this mode is gone. There is no other copy anywhere.
@@ -123,14 +121,14 @@ records:
   publicKey: /etc/records-owner.pub   # strongly recommended, see below
 ```
 
-The clip's key is wrapped by the SoC's key ladder under a key in one-time
-programmable memory, and it unwraps only on that die — and only into the crypto
-engine, never into memory. A card or a whole flash image is unreadable anywhere
-else, because the key is in neither.
+The camera's chip carries a key that was written into it once and cannot be read
+back out — not by software on the camera, not by anything reading the flash.
+Recordings are locked to that one chip: a card, or a whole copy of the flash,
+opens on no other camera.
 
-It does **not** protect a stolen camera. A key ladder unwraps for whoever can
-talk to it, so root on the camera can decrypt; and these boards have no secure
-boot, so a stolen camera is a camera with root.
+It does **not** protect a stolen camera. The chip will still do the unlocking for
+whoever is holding it, and these boards have no verified boot to stop someone
+getting a shell, so a stolen camera is a camera that decrypts its own clips.
 
 Provisioning is irreversible, once per slot for the life of the chip, and there
 are three slots:
@@ -143,11 +141,11 @@ majestic --otp-burn --otp-slot 1 --i-understand-this-is-irreversible
 reboot
 ```
 
-The key is drawn from the chip's hardware random generator mixed with the
-kernel's, used once, and never stored or printed. Majestic refuses to burn a
-slot that is not blank, refuses to record against a slot that is blank, and
-verifies the burn through the ladder afterwards. The daemon has to be stopped
-first, because it drives the same hardware.
+The key is random, used once, and never stored or shown to anybody — there is no
+copy of it, on the camera or off it. Majestic refuses to write to a slot that is
+already used, refuses to record against a slot that is still empty, and checks
+afterwards that the key really took. Stop the daemon first: it uses the same
+hardware, and the write needs it to itself.
 
 **Set `publicKey` as well.** A chip clip with nothing else in it cannot be opened
 off the camera at all, and cannot be opened by anybody once the camera is dead or
@@ -158,8 +156,8 @@ exactly as in the `pubkey` section above.
 
 - **Live streams.** RTSP, HLS, WebRTC and snapshots serve plaintext to whoever
   authenticates. This is about the card, not the network.
-- **The clip being written right now.** Its key is in RAM, or in the crypto
-  engine, for as long as that clip is open — in every mode, `pubkey` included.
+- **The clip being written right now.** Its key is on the camera for as long as
+  that clip is open — in every mode, `pubkey` included.
   What `pubkey` protects is the recordings already closed on the card; someone
   who takes a running camera and gets a shell still has the current clip, the
   live video, and everything recorded from then on.
@@ -179,7 +177,8 @@ exactly as in the `pubkey` section above.
 - **The cost while recording** is about 7% of one CPU core per MB/s written, so
   roughly 3-4% of a core at 4 Mbit/s on a Cortex-A7 class SoC. Most of that is
   the integrity chain rather than the cipher, and `chip` and `passphrase` cost
-  the same, because both use the crypto engine where the camera has one. Measure
+  the same, because both use the camera's own encryption hardware where it has
+  some. Measure
   your own: sum `utime`+`stime` across `/proc/$(pidof majestic)/task/*/stat` over
   a minute with encryption off, then again with it on, at the same bitrate.
 - **The web interface cannot play these yet.** Encrypted clips download and open

--- a/en/recording-encryption.md
+++ b/en/recording-encryption.md
@@ -1,0 +1,182 @@
+# OpenIPC Wiki
+[Table of Content](../README.md)
+
+## Encrypted recordings on the SD card
+
+A camera in a public place records to a card anyone can pull, in a body anyone
+can carry off. `records.encryption` decides what a thief gets. This page is what
+each setting protects, what it does not, and how to get a clip back afterwards.
+
+Before firmware from **September 2026** there was `records.key`, which XORed the
+payload with a repeating key and named the files `.enc`. That was obfuscation,
+not encryption — the key sat in `majestic.yaml` in plain text, the same key
+repeated over every frame, and nothing could play the result. It has been
+removed. If your config still carries `records.key` with `records.encryption`
+unset, the clips are being written in the clear and Majestic says so in the log.
+
+### Which mode protects what
+
+| what happened | `none` | `passphrase` | `chip` | `pubkey` |
+|---|---|---|---|---|
+| the card was pulled, or copied | readable | as strong as the passphrase | unreadable elsewhere | unreadable elsewhere |
+| the flash was cloned, `majestic.yaml` included | readable | **readable** | unreadable | unreadable |
+| the camera was stolen, and somebody has a shell on it | readable | readable | **readable** | unreadable |
+| the camera died, or the passphrase was lost | readable | readable | **lost** without a recovery key | readable with your private key |
+| plays in the web interface | yes | not yet | no | no |
+
+Only `pubkey` survives a stolen camera, and it is the one mode where the camera
+cannot play its own recordings. Everything else keeps something on the camera
+that opens the clip — and whoever has the camera has that too.
+
+### The file is still an MP4
+
+Whatever the mode, an encrypted recording is an ordinary fragmented MP4 using
+Common Encryption (`cenc`, AES-128-CTR), keeps its `.mp4` name, and plays with:
+
+```
+ffmpeg -decryption_key <32 hex characters> -i clip.mp4 -c copy clear.mp4
+```
+
+Each clip has its own key, drawn when the file is opened, and carries that key
+inside itself — wrapped, once per configured mode. Nothing on the camera has to
+remember which key went with which file, and no key is ever reused.
+
+Every fragment also carries a chained HMAC, so a clip that was cut, reordered or
+edited is detectable. `records_key.py verify` reports how far the chain holds.
+
+### `passphrase` — protects a card somebody removed
+
+```yaml
+records:
+  enabled: true
+  encryption: passphrase
+  key: "a long passphrase"
+```
+
+The passphrase is stretched with PBKDF2-HMAC-SHA256 (100 000 rounds, about a
+second on the camera, done once) and wraps each clip's key.
+
+It does **not** protect a stolen camera: the passphrase is in `majestic.yaml`,
+and anyone who can read the flash can read it. Use it when the risk you are
+addressing is a card walking out of a device that stays put.
+
+To open a clip, on your own machine, using
+[`tools/records_key.py`](https://github.com/OpenIPC/majestic/blob/master/tools/records_key.py)
+(standard library only, no dependencies):
+
+```
+records_key.py dump clip.mp4                                # what this clip carries
+records_key.py verify --passphrase 'a long passphrase' clip.mp4
+records_key.py unwrap  --passphrase 'a long passphrase' clip.mp4   # prints the hex key
+ffmpeg -decryption_key <that key> -i clip.mp4 -c copy clear.mp4
+```
+
+### `pubkey` — protects a stolen camera
+
+```yaml
+records:
+  encryption: pubkey
+  publicKey: /etc/records-owner.pub
+```
+
+Make the pair on your machine, and put **only the public half** on the camera:
+
+```
+openssl genrsa -out owner.pem 2048
+openssl rsa -in owner.pem -pubout -out owner.pub
+scp owner.pub root@camera:/etc/records-owner.pub
+```
+
+Each clip's key is sealed to that public key. The camera has no private half, by
+design, so nothing on it — not root, not a flash image, not the crypto engine —
+can open a recording. That is the point, and the costs follow from it: the
+camera cannot play its own clips, and after a restart it records beside the
+interrupted clip rather than resuming it.
+
+Recovery needs the private key, and never the camera:
+
+```
+records_key.py unwrap --rsa-blob blob.bin clip.mp4
+openssl pkeyutl -decrypt -inkey owner.pem -in blob.bin -out material.bin \
+    -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256 -pkeyopt rsa_mgf1_md:sha256
+records_key.py verify --material material.bin clip.mp4
+records_key.py unwrap --material material.bin clip.mp4      # the hex key for ffmpeg
+```
+
+**Keep `owner.pem` somewhere you will still have it in three years.** Lose it and
+every clip ever written in this mode is gone. There is no other copy anywhere.
+
+### `chip` — binds the clip to this camera's silicon
+
+HiSilicon gen 4 only for now (hi3516cv500/av300, hi3516ev200/ev300, gk7205v200),
+and only after a key has been burned into the chip.
+
+```yaml
+records:
+  encryption: chip
+  chipSlot: 1
+  publicKey: /etc/records-owner.pub   # strongly recommended, see below
+```
+
+The clip's key is wrapped by the SoC's key ladder under a key in one-time
+programmable memory, and it unwraps only on that die — and only into the crypto
+engine, never into memory. A card or a whole flash image is unreadable anywhere
+else, because the key is in neither.
+
+It does **not** protect a stolen camera. A key ladder unwraps for whoever can
+talk to it, so root on the camera can decrypt; and these boards have no secure
+boot, so a stolen camera is a camera with root.
+
+Provisioning is irreversible, once per slot for the life of the chip, and there
+are three slots:
+
+```
+majestic --otp-status                                  # engine, slots, what is programmed
+majestic --otp-burn --otp-slot 1 --dry-run             # everything except the write
+/etc/init.d/S95majestic stop
+majestic --otp-burn --otp-slot 1 --i-understand-this-is-irreversible
+reboot
+```
+
+The key is drawn from the chip's hardware random generator mixed with the
+kernel's, used once, and never stored or printed. Majestic refuses to burn a
+slot that is not blank, refuses to record against a slot that is blank, and
+verifies the burn through the ladder afterwards. The daemon has to be stopped
+first, because it drives the same hardware.
+
+**Set `publicKey` as well.** A chip clip with nothing else in it cannot be opened
+off the camera at all, and cannot be opened by anybody once the camera is dead or
+the board is replaced. The public key adds a recovery slot to every clip, opened
+exactly as in the `pubkey` section above.
+
+### What no mode protects
+
+- **Live streams.** RTSP, HLS, WebRTC and snapshots serve plaintext to whoever
+  authenticates. This is about the card, not the network.
+- **A camera that is running.** The key is in RAM or in the engine while it
+  records; only `pubkey` gives a thief nothing.
+- **Metadata.** File names carry the time, sizes carry the bitrate, and the frame
+  boundaries stay readable. Someone with the card knows when the camera recorded
+  and roughly how much was moving — not what.
+
+### Things that surprise people
+
+- **A mode Majestic cannot honour stops the recording** rather than writing in
+  the clear: a passphrase that is empty, a public key it cannot read, a blank
+  chip slot. The reason is in the log, and `records_state` in `/metrics` is not
+  zero. This is deliberate.
+- **Changing the mode costs up to one GOP of video.** The new clip has to start
+  on a keyframe, so on a camera with a 30-second GOP you lose up to 30 seconds at
+  the switch. Change it when nothing important is happening.
+- **The cost while recording** is about 7% of one CPU core per MB/s written —
+  roughly 3-4% of a core at 4 Mbit/s on a hi3516av300, most of it the integrity
+  chain rather than the cipher. `chip` and `passphrase` cost the same, because
+  both use the crypto engine where the camera has one.
+- **The web interface cannot play these yet.** Encrypted clips download and open
+  on your own machine with the recipes above.
+
+### See also
+
+- [Majestic example config](majestic-config.md) — the whole `records:` block
+- [`docs/recording-encryption.md`](https://github.com/OpenIPC/majestic/blob/master/docs/recording-encryption.md)
+  — the format, the box layout, and the threat model in detail


### PR DESCRIPTION
Majestic gained real at-rest encryption for SD recordings (OpenIPC/majestic 781c635cf): CENC fragmented MP4 with three key modes, replacing the `records.key` XOR that named files `.enc`.

This adds `en/recording-encryption.md` — which theft each mode survives, what to put in `majestic.yaml`, the `--otp-burn` provisioning for chip mode, and the exact `records_key.py` + `openssl` + `ffmpeg` recipes for getting a clip back on your own machine. Linked from the table of contents.

It also fixes the `records:` block in `en/majestic-config.md`, which still documented `key: ""` as the XOR obfuscation and named the output `.enc`. That option no longer exists; the block now lists `encryption`, `key`, `publicKey` and `chipSlot`.

The three things a reader most needs and would otherwise learn the hard way: `passphrase` does not protect a stolen camera, `chip` does not either, and a `chip` clip with no `publicKey` beside it dies with the board.

cspell clean.