### PR TITLE
Majestic: a lamp wired the other way round, and where to say so

### DIFF
--- a/en/gpio-settings.md
+++ b/en/gpio-settings.md
@@ -238,6 +238,13 @@ Tested on GK7205V300 for /dev/ttyАМА1:
 > IRCTL is a backlightPin<br>
 > IRSTATUS is a lightSensorPin
 
+**A pad marked inverted has a setting, not a workaround.** Where a board holds a
+pad LOW for the active state, say so in the configuration rather than rewiring:
+`nightMode.backlightInvert` for the lamp, `nightMode.lightSensorInvert` for the
+daylight sensor, `nightMode.irCutSingleInvert` for a filter driven from a single
+pad. Boards whose lamp is active-low otherwise light the illuminator all day and
+switch it off at nightfall. The IRCUT **pair** needs none of this — see below.
+
 **The two IRCUT pads are one H-bridge, and their order matters.** They are not
 independent switches: which of them is driven high while the other is held low is
 what decides whether the filter closes or opens, so a swapped pair gives you a

--- a/en/majestic-config.md
+++ b/en/majestic-config.md
@@ -235,6 +235,8 @@ nightMode:                      # see en/ircut-filter.md for how the filter is
   irCutSingleInvert: false      # for a board with a single coil pad
   #backlightEnabled: true       # false parks the lamp: wiring kept, stays dark
   #backlightPin: 65
+  backlightInvert: false        # true when the lamp lights on a LOW pad;
+                                # covers the PWM lamp below as well
   colorToGray: true
   #overrideDrc: 300
   #minThreshold: 2000           # compared against isp_again, whose units are

--- a/en/majestic-streamer.md
+++ b/en/majestic-streamer.md
@@ -366,6 +366,33 @@ curl http://localhost/api/v1/config --data-binary @- <<'EOF'
 EOF
 ```
 
+### A lamp wired the other way round
+
+Some boards drive the illuminator **active-low**: the pad has to be held low to
+light it. On those, a camera that has been told nothing lights the lamp all day
+and switches it off at nightfall — which is the one fault here that looks like
+the camera working, because the lamp is plainly under control, just backwards.
+
+```yaml
+nightMode:
+  backlightPin: 59
+  backlightInvert: true       # default false
+```
+
+With it on, night holds the pad low and day holds it high. The lamp is also
+left **off** rather than on at the moments the camera is not deciding — while a
+day/night setting is being applied, and on an orderly shutdown — which for an
+active-low board means the pad is held high rather than simply let go. The
+setting describes the lamp rather than the pad, so it covers the dimmable lamp
+below as well.
+
+It shows up as *Camera light is inverted* on **Settings → Day / Night** and
+applies as soon as it is saved; the video stream is not restarted. There is no
+equivalent for the two IR-cut coils and none is needed: they are one H-bridge,
+and which way the filter moves is decided by which pad you put in `irCutPin1`.
+A single-pad filter has `irCutSingleInvert`, and the daylight sensor has
+`lightSensorInvert`.
+
 ### PWM backlight: a dimmable lamp
 
 On the HiSilicon EV200/EV300 and Goke GK7205V200/V500 family, a lamp wired to
@@ -381,13 +408,18 @@ nightMode:
   backlightPwmMax: 100
 ```
 
-With a channel set, `backlightPin` is ignored. At night the lamp lights at the
-maximum and then trims itself to the ambient light every couple of seconds —
-brighter when the scene is starving, dimmer when the lamp overshoots — between
-the two duty bounds. The lamp's own light can never talk the camera back into
-day: the trim stops dimming well above the day threshold, so only real dawn
-ends the night. The current percentage is the `night_light_duty` gauge on
-`/metrics`, and the dashboard's day/night line shows it as "lamp 43%".
+With a channel set, `backlightPin` is ignored, but `backlightInvert` is not:
+on an active-low driver the duty still reads as brightness, 0 for dark and 100
+for full, and the lamp is still left off at the moments the camera is not
+deciding.
+
+At night the lamp lights at the maximum and then trims itself to the ambient
+light every couple of seconds — brighter when the scene is starving, dimmer
+when the lamp overshoots — between the two duty bounds. The lamp's own light
+can never talk the camera back into day: the trim stops dimming well above the
+day threshold, so only real dawn ends the night. The current percentage is the
+`night_light_duty` gauge on `/metrics`, and the dashboard's day/night line
+shows it as "lamp 43%".
 
 ### Stopping the sensor and ISP when nothing is watching
 


### PR DESCRIPTION
Every GPIO pad Majestic drives or reads has a setting for a board that wires
it the other way round — except, until now, the camera light. A board whose
illuminator is active-low lit it all day and switched it off at nightfall,
with nothing in the configuration able to correct it, and no way out but
inverting it in hardware or leaving the lamp unconfigured.

`nightMode.backlightInvert` (boolean, default `false`) is that setting, and
these pages now say so in the three places a reader arrives from.

**majestic-streamer.md** gets a short section beside the dimmable-lamp one,
because that is where the lamp is already described. It gives the two lines of
YAML, says what changes (night holds the pad low, day holds it high), and says
what does not: the lamp is still left off at the moments the camera is not
deciding, which on an active-low board is the pad held high rather than let
go. It also answers the question the setting raises next — why the IR-cut
*pair* needs no equivalent, when everything around it has one.

The PWM paragraph gains one sentence for the same reason: with a channel set
`backlightPin` is ignored, so a reader could reasonably conclude the polarity
setting is ignored with it. It is not, and the duty still reads as brightness
either way.

**gpio-settings.md** is where someone lands with a board whose pad is marked
inverted, and the legend under the tables mapped columns to keys without ever
mentioning that polarity is configurable at all. It now names all three
polarity settings, and points at the H-bridge paragraph below for the pair
that needs none.

**majestic-config.md** gains the key in the `nightMode` block, next to the pin
it qualifies.

The symptom is worth the words it costs here. It is the one fault in this area
that looks like the camera working — the lamp is plainly under control, just
backwards — and it shows itself at the hour nobody is looking.

Behaviour verified on a HiSilicon EV300 + IMX335, both polarities, on the
switched lamp and the dimmed one, by reading the pad back rather than trusting
the configuration.
