### PR TITLE
help-uboot: install defib from the repository, not from PyPI

### DIFF
--- a/en/help-uboot.md
+++ b/en/help-uboot.md
@@ -412,24 +412,39 @@ The command-line tool supports every SoC — including the frame-blast parts the
 browser cannot drive — and adds flash restore, a high-speed bare-metal flash
 agent and full unattended installs:
 
+defib is not on PyPI, so install it from the repository — `uv tool install
+defib` finds some other package, or nothing at all:
+
 ```shell
-uv tool install defib     # or: pipx install defib
+uv tool install git+https://github.com/OpenIPC/defib
+# or: pipx install git+https://github.com/OpenIPC/defib
 defib list-chips
-defib burn -c hi3516ev300 -p /dev/ttyUSB0 -t
+defib burn -c hi3516ev300 -p /dev/ttyUSB0 -b -t
 ```
 
-Start it before you power-cycle the camera, exactly as in the browser. The `-t`
-flag drops you into the U-Boot console once the upload finishes. To take a
-backup first:
+Start it before you power-cycle the camera, exactly as in the browser. `-b`
+sends Ctrl-C as soon as the upload lands and `-t` opens the console, and you
+want both: the bootloader you just uploaded lives only in RAM, so if it
+autoboots into a flash that cannot boot, it resets — and the reset throws away
+the copy you uploaded, leaving the terminal talking to a dead board again.
+
+To take a backup first:
 
 ```shell
-defib agent read -c hi3516ev300 -p /dev/ttyUSB0 -o flash_backup.bin
+defib dump-flash -p /dev/ttyUSB0 -o flash_backup.bin
 ```
+
+That reads the flash out through the U-Boot console and needs nothing else
+installed. There is a much faster route, `defib agent read`, but the flash
+agent is bare-metal code compiled per SoC and no prebuilt binary ships in the
+package — you need a defib checkout and `make SOC=<soc>` in its `agent/`
+directory before `defib agent` will do anything.
 
 If a later `sf erase` appears to succeed but the data does not change, the
 vendor bootloader has armed the flash's status-register block protection —
 watch for `WPS=1` or `Total Lock Blks` in the boot log. The `defib agent` path
-clears those lock bits explicitly before erasing.
+clears those lock bits explicitly before erasing, which is the one job worth
+building the agent for.
 
 #### Shorting pins on flash chip
 

--- a/en/help-uboot.md
+++ b/en/help-uboot.md
@@ -443,8 +443,7 @@ directory before `defib agent` will do anything.
 If a later `sf erase` appears to succeed but the data does not change, the
 vendor bootloader has armed the flash's status-register block protection —
 watch for `WPS=1` or `Total Lock Blks` in the boot log. The `defib agent` path
-clears those lock bits explicitly before erasing, which is the one job worth
-building the agent for.
+clears those lock bits explicitly before erasing.
 
 #### Shorting pins on flash chip
 


### PR DESCRIPTION
The side-loading section told readers to run `uv tool install defib`. defib has never been published to PyPI, so that installs an unrelated package or nothing at all — defib's own README was corrected for this in OpenIPC/defib@c163d87, this page was not.

The reporter in [OpenIPC/firmware#2381](https://github.com/OpenIPC/firmware/issues/2381), mid-recovery on a bricked Hi3516CV300, took the line literally enough to paste it into a Python REPL:

```
>>> uv tool install git+https://github.com/OpenIPC/defib
  File "<python-input-0>", line 1
    uv tool install git+https://github.com/OpenIPC/defib
    ^^^^
SyntaxError: invalid syntax
```

Two more things in the same block sent that same reader into a wall, so they are fixed here too.

**`burn -t` alone does not stop the autoboot,** and the page recommended exactly that. The bootloader being uploaded lives only in RAM, so on a camera whose flash cannot boot it autoboots, fails and resets — and the reset discards the RAM copy, leaving the terminal attached to a board that is dead again:

```
Wrong Image Format for bootm command
ERROR: can't get kernel image!
resetting ...

--- Terminal mode (Ctrl-C to exit) ---
```

It reads as the tool not working, which is what the reporter concluded. `-b` sends the Ctrl-C that avoids it, and the page now recommends `-b -t` with the reason.

**The backup step recommended `defib agent read`,** which cannot work for anyone who followed the install line above it. The flash agent is bare-metal code compiled per SoC and no prebuilt binary ships in the package, so `defib agent` refuses outright. The page now recommends `defib dump-flash`, which reads the flash out through the U-Boot console and needs nothing built, and says what the agent actually costs — while keeping it named for the status-register lock bits, which are the one job worth building it for.

Related: [OpenIPC/defib#135](https://github.com/OpenIPC/defib/pull/135) makes that refusal explain itself instead of saying "No agent binary for 'hi3516cv300'", which reads as an unsupported chip.

### Testing

Documentation only — no build, no camera. Worth noting that the repo's `cspell.yaml` does not gate anything: there is no workflow in this repository, and the config is inert regardless — its markdown `ignoreRegExpList` includes `/[A-Z]*/g`, which matches an empty string at every position, so a deliberate misspelling in plain prose goes unreported. I checked with cspell 8.19.4 in a container rather than assume. Unrelated to this change, but someone may want to look at it.