### PR TITLE
help-uboot: say what the layout macro is for, and that serial needs it too

### DIFF
--- a/en/help-uboot.md
+++ b/en/help-uboot.md
@@ -232,7 +232,12 @@ after the image is loaded, continue
 sf probe 0
 sf erase 0x0 ${flashsize}
 sf write ${baseaddr} 0x0 ${filesize}
+reset
 ```
+
+Then interrupt the boot once more and
+[set the partition layout](#setting-the-partition-layout-after-a-full-image) —
+without it a 16MB image boots to a kernel panic.
 
 ### Flashing full image from TFTP
 
@@ -258,7 +263,7 @@ Example for 8MB:
 
 ```shell
 mw.b ${baseaddr} 0xff ${flashsize}
-tftpboot ${baseaddr} openipc-${soc}-lite-8mb.bin
+tftpboot ${baseaddr} openipc-${soc}-nor-lite-8mb.bin
 sf probe 0; sf erase 0x0 ${flashsize}; sf write ${baseaddr} 0x0 ${filesize}
 reset
 ```
@@ -267,13 +272,51 @@ Example for 16MB:
 
 ```shell
 mw.b ${baseaddr} 0xff ${flashsize}
-tftpboot ${baseaddr} openipc-${soc}-ultimate-16mb.bin
+tftpboot ${baseaddr} openipc-${soc}-nor-ultimate-16mb.bin
 sf probe 0; sf erase 0x0 ${flashsize}; sf write ${baseaddr} 0x0 ${filesize}
 reset
 ```
 
-At the first boot, sign in into the bootloader shell once again and remap
-partitioning running `run setnor16m` command.
+At the first boot, interrupt the boot again and
+[set the partition layout](#setting-the-partition-layout-after-a-full-image).
+
+### Setting the partition layout after a full image
+
+A full image carries the bootloader with it, and the bootloader's compiled-in
+default is the 8MB partition map:
+
+```
+mtdparts=hi_sfc:256k(boot),64k(env),2048k(kernel),5120k(rootfs),-(rootfs_data)
+```
+
+The 16MB map is a separate macro, and it does not merely make the rootfs
+longer — it moves it, to 0x350000 from 0x250000, with 10240k rather than 5120k.
+The images openipc.org builds for a 16MB chip are laid out that way, so a 16MB
+image left on the 8MB default has its rootfs where the kernel does not look:
+
+```
+0x000000250000-0x000000750000 : "rootfs"
+No filesystem could mount root, tried:  squashfs
+Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(31,3)
+Rebooting in 20 seconds..
+```
+
+The kernel starts either way, because it sits at 0x50000 in both maps, so the
+camera looks like it is booting right up to the panic — and then loops every
+20 seconds.
+
+Interrupt the boot and run the macro for the layout you flashed:
+
+```shell
+run setnor8m     # 8MB layout
+run setnor16m    # 16MB layout
+run setnand      # NAND
+```
+
+Each of them sets the partition map, points `bootcmd` at it, saves the
+environment and resets, so there is nothing to type afterwards. Nothing needs
+re-flashing either — the image on the chip is already correct, only the map it
+is read with was wrong.
 
 ### Reading binary image from SD card.
 


### PR DESCRIPTION
A full image carries the bootloader, and the bootloader's compiled-in default is the **8MB** partition map. The 16MB map is a separate macro, and it does not merely lengthen the rootfs — it moves it:

```
mtdparts        = ...,2048k(kernel),5120k(rootfs),...    -> rootfs at 0x250000
mtdpartsnor16m  = ...,3072k(kernel),10240k(rootfs),...   -> rootfs at 0x350000
```

openipc.org builds its 16MB images to the second one, so skipping the macro leaves the kernel looking at 0x250000, finding erased flash, and panicking on root mount every 20 seconds. The kernel itself starts either way — it sits at 0x50000 in both maps — so the camera looks like it is booting right up to the panic.

### What changed

**The step now has a section of its own**, with the symptom quoted, so it is findable by the panic and not only readable in order. The page did already say to run `setnor16m` — as one trailing sentence after the 16MB example, with no reason given and no mention of `setnor8m` or `setnand`. The reporter in [OpenIPC/firmware#2381](https://github.com/OpenIPC/firmware/issues/2381) hit the panic regardless, having been given the flash commands by hand; they had a bricked Hi3516CV300, got as far as a correctly written 16MB chip, and then a boot loop.

**The serial full-image section did not mention it at all** — and ended after `sf write` with no `reset` either. Same full image, same default, same panic. Both sections now point at the new one.

**`-nor-` added to the two TFTP example filenames.** openipc.org serves `openipc-<soc>-nor-<release>-<size>mb.bin`; the examples read `openipc-${soc}-lite-8mb.bin`, so a reader copying either line got a TFTP failure rather than an image.

### Scope

Several other pages carry the older filename shape, some of them for FPV images that come from OpenIPC/builder rather than the site generator, and I have not verified how those are named. They are left alone rather than swept on an assumption — worth someone checking separately.

### Testing

Documentation only. Verified the two claims against the sources rather than from memory:

- `openipc/u-boot-hi3516cv200`, `include/configs/hi-common.h` — the compiled-in `mtdparts` is the 8MB map, and `setnor16m=run mtdpartsnor16m; setenv bootcmd ${bootcmdnor}; saveenv; reset`, which is why nothing needs typing after it.
- `openipc/website`, `app/models/flash_layout.rb` — `NOR[16]` assembles with `rootfs_offset: 0x350000`, and its own comment notes that flashing a full image leaves the environment on the 8MB default.

The filename shape is `Firmware.filename_for` in the same repository, and matches the name the reporter downloaded successfully in the issue.

As with #517: this repository has no workflows, and its `cspell.yaml` is inert — the markdown `ignoreRegExpList` includes `/[A-Z]*/g`, which matches an empty string everywhere, so a deliberate misspelling in prose goes unreported. Nothing here spell-checks.